### PR TITLE
Fix discount-aware reporting and add Stripe charge sync command

### DIFF
--- a/app/Console/Commands/SyncStripeCharges.php
+++ b/app/Console/Commands/SyncStripeCharges.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\ConnectedCharges\SyncConnectedChargesFromStripe;
+use App\Models\Store;
+use Illuminate\Console\Command;
+
+class SyncStripeCharges extends Command
+{
+    protected $signature = 'stripe:sync-charges {store? : Store slug or ID. If not provided, syncs all stores with Stripe accounts}';
+
+    protected $description = 'Sync charges from Stripe connected accounts into ConnectedCharge models (updates captured, refunded, status, etc.)';
+
+    public function handle(SyncConnectedChargesFromStripe $syncAction): int
+    {
+        $storeSlug = $this->argument('store');
+
+        if ($storeSlug) {
+            $store = Store::where('slug', $storeSlug)->first();
+
+            if (! $store && is_numeric($storeSlug)) {
+                $store = Store::find($storeSlug);
+            }
+
+            if (! $store) {
+                $this->error("Store '{$storeSlug}' not found.");
+
+                return self::FAILURE;
+            }
+
+            if (! $store->stripe_account_id) {
+                $this->error("Store '{$store->name}' does not have a Stripe account ID.");
+
+                return self::FAILURE;
+            }
+
+            $this->info("Syncing charges for store: {$store->name} (ID: {$store->id})");
+
+            $result = $syncAction($store, false);
+
+            $this->displayResults($result, $store->name);
+
+            return self::SUCCESS;
+        }
+
+        $stores = Store::whereNotNull('stripe_account_id')->get();
+
+        if ($stores->isEmpty()) {
+            $this->warn('No stores with Stripe accounts found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Found {$stores->count()} store(s) with Stripe accounts. Syncing charges...\n");
+
+        $totalFound = 0;
+        $totalCreated = 0;
+        $totalUpdated = 0;
+        $allErrors = [];
+
+        foreach ($stores as $store) {
+            $this->line("Syncing charges for: {$store->name} ({$store->stripe_account_id})");
+
+            $result = $syncAction($store, false);
+
+            $totalFound += $result['total'];
+            $totalCreated += $result['created'];
+            $totalUpdated += $result['updated'];
+            $allErrors = array_merge($allErrors, $result['errors']);
+
+            $this->line("  → Found: {$result['total']}, Created: {$result['created']}, Updated: {$result['updated']}");
+
+            if (! empty($result['errors'])) {
+                $this->warn('  → Errors: '.count($result['errors']));
+            }
+        }
+
+        $this->newLine();
+        $this->info('Summary across all stores:');
+        $this->info("  Total found: {$totalFound}");
+        $this->info("  Total created: {$totalCreated}");
+        $this->info("  Total updated: {$totalUpdated}");
+
+        if (! empty($allErrors)) {
+            $this->warn('  Total errors: '.count($allErrors));
+            if ($this->option('verbose')) {
+                foreach ($allErrors as $error) {
+                    $this->error("    - {$error}");
+                }
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function displayResults(array $result, string $storeName): void
+    {
+        $this->newLine();
+        $this->info("Sync completed for {$storeName}:");
+        $this->info("  Found: {$result['total']}");
+        $this->info("  Created: {$result['created']}");
+        $this->info("  Updated: {$result['updated']}");
+
+        if (! empty($result['errors'])) {
+            $this->warn('  Errors: '.count($result['errors']));
+            if ($this->option('verbose')) {
+                foreach ($result['errors'] as $error) {
+                    $this->error("    - {$error}");
+                }
+            }
+        }
+    }
+}

--- a/app/Filament/Resources/PosPurchases/Schemas/PosPurchaseInfolist.php
+++ b/app/Filament/Resources/PosPurchases/Schemas/PosPurchaseInfolist.php
@@ -42,8 +42,16 @@ class PosPurchaseInfolist
                 $discountValue = $item['discount_amount'] ?? 0;
 
                 if (is_string($discountValue)) {
-                    $parsed = str_replace([',', ' '], ['.', ''], $discountValue);
-                    $discountOre = (int) round((float) $parsed * 100);
+                    $hasFormatting = str_contains($discountValue, ',')
+                        || str_contains($discountValue, ' ')
+                        || (str_contains($discountValue, '.') && preg_match('/\.\d{2}$/', $discountValue));
+
+                    if ($hasFormatting) {
+                        $parsed = str_replace([',', ' '], ['.', ''], $discountValue);
+                        $discountOre = (int) round((float) $parsed * 100);
+                    } else {
+                        $discountOre = (int) round((float) $discountValue);
+                    }
                 } else {
                     $discountOre = is_numeric($discountValue) ? (int) $discountValue : 0;
                 }

--- a/app/Filament/Resources/PosPurchases/Schemas/PosPurchaseInfolist.php
+++ b/app/Filament/Resources/PosPurchases/Schemas/PosPurchaseInfolist.php
@@ -16,6 +16,60 @@ use Filament\Support\Icons\Heroicon;
 class PosPurchaseInfolist
 {
     /**
+     * Resolve total discounts for display in øre.
+     * Prefers explicit metadata value, then item-level discounts, then subtotal-total fallback.
+     */
+    public static function resolveTotalDiscountsOreForDisplay($record): int
+    {
+        $metadata = $record->metadata ?? [];
+
+        if (isset($metadata['total_discounts']) && is_numeric($metadata['total_discounts'])) {
+            $explicitDiscounts = (int) $metadata['total_discounts'];
+            if ($explicitDiscounts > 0) {
+                return $explicitDiscounts;
+            }
+        }
+
+        $itemLevelDiscounts = 0;
+        $items = $metadata['items'] ?? [];
+        if (is_array($items)) {
+            foreach ($items as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                $quantity = isset($item['quantity']) ? (float) $item['quantity'] : 1.0;
+                $discountValue = $item['discount_amount'] ?? 0;
+
+                if (is_string($discountValue)) {
+                    $parsed = str_replace([',', ' '], ['.', ''], $discountValue);
+                    $discountOre = (int) round((float) $parsed * 100);
+                } else {
+                    $discountOre = is_numeric($discountValue) ? (int) $discountValue : 0;
+                }
+
+                if ($discountOre > 0) {
+                    $itemLevelDiscounts += (int) round($discountOre * $quantity);
+                }
+            }
+        }
+
+        if ($itemLevelDiscounts > 0) {
+            return $itemLevelDiscounts;
+        }
+
+        $subtotalOre = isset($metadata['subtotal']) && is_numeric($metadata['subtotal']) ? (int) $metadata['subtotal'] : null;
+        $totalOre = isset($metadata['total']) && is_numeric($metadata['total']) ? (int) $metadata['total'] : (int) ($record->amount ?? 0);
+        $tipOre = isset($metadata['tip_amount']) && is_numeric($metadata['tip_amount']) ? (int) $metadata['tip_amount'] : 0;
+
+        if ($subtotalOre !== null) {
+            return max(0, $subtotalOre + $tipOre - $totalOre);
+        }
+
+        return 0;
+    }
+
+    /**
      * Get tax rate (0-1) for an article group code. Uses ArticleGroupCode model, defaults to 25%.
      */
     public static function getTaxRateForArticleGroupCode(?string $code): float
@@ -435,8 +489,7 @@ class PosPurchaseInfolist
                         TextEntry::make('discounts_display')
                             ->label('Discounts')
                             ->formatStateUsing(function ($state, $record) {
-                                $metadata = $record->metadata ?? [];
-                                $discounts = ($metadata['total_discounts'] ?? 0) / 100;
+                                $discounts = self::resolveTotalDiscountsOreForDisplay($record) / 100;
                                 if ($discounts <= 0) {
                                     return null;
                                 }
@@ -446,7 +499,7 @@ class PosPurchaseInfolist
                             ->badge()
                             ->color('success')
                             ->icon(Heroicon::OutlinedTag)
-                            ->visible(fn ($record) => ($record->metadata['total_discounts'] ?? 0) > 0),
+                            ->visible(fn ($record) => self::resolveTotalDiscountsOreForDisplay($record) > 0),
 
                         RepeatableEntry::make('tax_breakdown')
                             ->label('Tax')

--- a/app/Filament/Resources/PosSessions/Tables/PosSessionsTable.php
+++ b/app/Filament/Resources/PosSessions/Tables/PosSessionsTable.php
@@ -937,6 +937,99 @@ class PosSessionsTable
         return 0;
     }
 
+    /**
+     * Parse total discounts from receipt/metadata payload (returns øre).
+     */
+    protected static function parseTotalDiscountsFromPayload(array $payload): int
+    {
+        if (isset($payload['total_discounts'])) {
+            return max(0, self::parsePriceFromReceiptItem($payload['total_discounts']));
+        }
+
+        $discounts = $payload['discounts'] ?? [];
+        if (! is_array($discounts)) {
+            return 0;
+        }
+
+        $sum = 0;
+        foreach ($discounts as $discount) {
+            if (! is_array($discount) || ! isset($discount['amount'])) {
+                continue;
+            }
+            $sum += max(0, self::parsePriceFromReceiptItem($discount['amount']));
+        }
+
+        return $sum;
+    }
+
+    /**
+     * Apply item-level and cart-level discounts to parsed line items.
+     *
+     * @param  array<int, array<string, mixed>>  $lineItems
+     * @return array<int, array<string, mixed>>
+     */
+    protected static function applyDiscountsToLineItems(array $lineItems, int $totalDiscountsOre): array
+    {
+        if (empty($lineItems)) {
+            return $lineItems;
+        }
+
+        $itemDiscounts = 0;
+        $discountableBase = 0;
+
+        foreach ($lineItems as &$lineItem) {
+            $gross = max(0, (int) ($lineItem['line_total'] ?? 0));
+            $itemDiscount = max(0, (int) ($lineItem['item_discount'] ?? 0));
+            $itemDiscount = min($itemDiscount, $gross);
+
+            $lineItem['line_total'] = $gross;
+            $lineItem['item_discount'] = $itemDiscount;
+            $lineItem['net_before_cart_discount'] = max(0, $gross - $itemDiscount);
+
+            $itemDiscounts += $itemDiscount;
+            $discountableBase += $lineItem['net_before_cart_discount'];
+        }
+        unset($lineItem);
+
+        $remainingCartDiscount = max(0, $totalDiscountsOre - $itemDiscounts);
+        if ($remainingCartDiscount <= 0 || $discountableBase <= 0) {
+            foreach ($lineItems as &$lineItem) {
+                $lineItem['line_total'] = $lineItem['net_before_cart_discount'];
+                unset($lineItem['net_before_cart_discount']);
+            }
+            unset($lineItem);
+
+            return $lineItems;
+        }
+
+        $indices = array_keys($lineItems);
+        $lastIndex = end($indices);
+        $allocated = 0;
+
+        foreach ($lineItems as $index => &$lineItem) {
+            $base = $lineItem['net_before_cart_discount'];
+            if ($base <= 0) {
+                $lineItem['line_total'] = 0;
+                unset($lineItem['net_before_cart_discount']);
+
+                continue;
+            }
+
+            if ($index === $lastIndex) {
+                $cartShare = $remainingCartDiscount - $allocated;
+            } else {
+                $cartShare = (int) floor(($remainingCartDiscount * $base) / $discountableBase);
+                $allocated += $cartShare;
+            }
+
+            $lineItem['line_total'] = max(0, $base - $cartShare);
+            unset($lineItem['net_before_cart_discount']);
+        }
+        unset($lineItem);
+
+        return $lineItems;
+    }
+
     public static function calculateProductsSold(PosSession $session): \Illuminate\Support\Collection
     {
         $session->load(['receipts.charge', 'charges']);
@@ -1027,6 +1120,12 @@ class PosSessionsTable
         // Process receipts
         foreach ($salesReceipts as $receipt) {
             $items = $receipt->receipt_data['items'] ?? [];
+            $receiptData = is_array($receipt->receipt_data) ? $receipt->receipt_data : [];
+            $receiptTotalDiscounts = self::parseTotalDiscountsFromPayload($receiptData);
+            if ($receiptTotalDiscounts === 0 && $receipt->charge && is_array($receipt->charge->metadata)) {
+                $receiptTotalDiscounts = self::parseTotalDiscountsFromPayload($receipt->charge->metadata);
+            }
+            $lineItems = [];
 
             foreach ($items as $item) {
                 $productId = $item['product_id'] ?? null;
@@ -1052,6 +1151,14 @@ class PosSessionsTable
                     $lineTotal = (int) round($unitPrice * $quantity);
                 }
 
+                $itemDiscount = 0;
+                if (isset($item['discount_total_amount'])) {
+                    $itemDiscount = max(0, self::parsePriceFromReceiptItem($item['discount_total_amount']));
+                } elseif (isset($item['discount_amount'])) {
+                    $discountPerUnit = max(0, self::parsePriceFromReceiptItem($item['discount_amount']));
+                    $itemDiscount = (int) round($discountPerUnit * $quantity);
+                }
+
                 // Get product information
                 $product = null;
                 $productName = $item['name'] ?? $item['product_name'] ?? 'Ukjent produkt';
@@ -1073,20 +1180,36 @@ class PosSessionsTable
                     $productKey = 'name_'.md5($productName);
                 }
 
+                $lineItems[] = [
+                    'key' => $productKey,
+                    'name' => $productName,
+                    'product_id' => $productId,
+                    'variant_id' => $variantId,
+                    'quantity' => $quantity,
+                    'line_total' => $lineTotal,
+                    'item_discount' => $itemDiscount,
+                ];
+            }
+
+            $lineItems = self::applyDiscountsToLineItems($lineItems, $receiptTotalDiscounts);
+
+            foreach ($lineItems as $lineItem) {
+                $productKey = $lineItem['key'];
+
                 if (! $productsSold->has($productKey)) {
                     $productsSold->put($productKey, [
                         'key' => $productKey,
-                        'name' => $productName,
-                        'product_id' => $productId,
-                        'variant_id' => $variantId,
+                        'name' => $lineItem['name'],
+                        'product_id' => $lineItem['product_id'],
+                        'variant_id' => $lineItem['variant_id'],
                         'quantity' => 0.0,
                         'amount' => 0,
                     ]);
                 }
 
                 $current = $productsSold->get($productKey);
-                $current['quantity'] += $quantity;
-                $current['amount'] += $lineTotal;
+                $current['quantity'] += (float) $lineItem['quantity'];
+                $current['amount'] += (int) $lineItem['line_total'];
                 $productsSold->put($productKey, $current);
             }
         }
@@ -1094,6 +1217,9 @@ class PosSessionsTable
         // Process charges without receipts (fallback to charge metadata)
         foreach ($chargesWithoutReceipts as $charge) {
             $items = $charge->metadata['items'] ?? [];
+            $metadata = is_array($charge->metadata) ? $charge->metadata : [];
+            $metadataTotalDiscounts = self::parseTotalDiscountsFromPayload($metadata);
+            $lineItems = [];
 
             foreach ($items as $item) {
                 $productId = $item['product_id'] ?? null;
@@ -1110,6 +1236,14 @@ class PosSessionsTable
                     $lineTotal = (int) round($unitPrice * $quantity);
                 }
 
+                $itemDiscount = 0;
+                if (isset($item['discount_total_amount'])) {
+                    $itemDiscount = max(0, self::parsePriceFromReceiptItem($item['discount_total_amount']));
+                } elseif (isset($item['discount_amount'])) {
+                    $discountPerUnit = max(0, self::parsePriceFromReceiptItem($item['discount_amount']));
+                    $itemDiscount = (int) round($discountPerUnit * $quantity);
+                }
+
                 // Get product information
                 $product = null;
                 $productName = $item['name'] ?? $item['product_name'] ?? 'Ukjent produkt';
@@ -1131,20 +1265,36 @@ class PosSessionsTable
                     $productKey = 'name_'.md5($productName);
                 }
 
+                $lineItems[] = [
+                    'key' => $productKey,
+                    'name' => $productName,
+                    'product_id' => $productId,
+                    'variant_id' => $variantId,
+                    'quantity' => $quantity,
+                    'line_total' => $lineTotal,
+                    'item_discount' => $itemDiscount,
+                ];
+            }
+
+            $lineItems = self::applyDiscountsToLineItems($lineItems, $metadataTotalDiscounts);
+
+            foreach ($lineItems as $lineItem) {
+                $productKey = $lineItem['key'];
+
                 if (! $productsSold->has($productKey)) {
                     $productsSold->put($productKey, [
                         'key' => $productKey,
-                        'name' => $productName,
-                        'product_id' => $productId,
-                        'variant_id' => $variantId,
+                        'name' => $lineItem['name'],
+                        'product_id' => $lineItem['product_id'],
+                        'variant_id' => $lineItem['variant_id'],
                         'quantity' => 0.0,
                         'amount' => 0,
                     ]);
                 }
 
                 $current = $productsSold->get($productKey);
-                $current['quantity'] += $quantity;
-                $current['amount'] += $lineTotal;
+                $current['quantity'] += (float) $lineItem['quantity'];
+                $current['amount'] += (int) $lineItem['line_total'];
                 $productsSold->put($productKey, $current);
             }
         }
@@ -1201,6 +1351,12 @@ class PosSessionsTable
 
         foreach ($salesReceipts as $receipt) {
             $items = $receipt->receipt_data['items'] ?? [];
+            $receiptData = is_array($receipt->receipt_data) ? $receipt->receipt_data : [];
+            $receiptTotalDiscounts = self::parseTotalDiscountsFromPayload($receiptData);
+            if ($receiptTotalDiscounts === 0 && $receipt->charge && is_array($receipt->charge->metadata)) {
+                $receiptTotalDiscounts = self::parseTotalDiscountsFromPayload($receipt->charge->metadata);
+            }
+            $lineItems = [];
 
             foreach ($items as $item) {
                 $productId = $item['product_id'] ?? null;
@@ -1226,6 +1382,14 @@ class PosSessionsTable
                     $lineTotal = (int) round($unitPrice * $quantity);
                 }
 
+                $itemDiscount = 0;
+                if (isset($item['discount_total_amount'])) {
+                    $itemDiscount = max(0, self::parsePriceFromReceiptItem($item['discount_total_amount']));
+                } elseif (isset($item['discount_amount'])) {
+                    $discountPerUnit = max(0, self::parsePriceFromReceiptItem($item['discount_amount']));
+                    $itemDiscount = (int) round($discountPerUnit * $quantity);
+                }
+
                 // Get product to find its vendor
                 $product = null;
                 if ($variantId && isset($variants[$variantId])) {
@@ -1249,10 +1413,27 @@ class PosSessionsTable
                     $commissionPercent = $vendor->commission_percent;
                 }
 
+                $lineItems[] = [
+                    'vendor_id' => $vendorId,
+                    'vendor_name' => $vendorName,
+                    'quantity' => $quantity,
+                    'line_total' => $lineTotal,
+                    'item_discount' => $itemDiscount,
+                    'commission_percent' => $commissionPercent,
+                ];
+            }
+
+            $lineItems = self::applyDiscountsToLineItems($lineItems, $receiptTotalDiscounts);
+
+            foreach ($lineItems as $lineItem) {
+                $vendorId = $lineItem['vendor_id'];
+                $commissionPercent = $lineItem['commission_percent'];
+                $lineTotal = (int) $lineItem['line_total'];
+
                 if (! $vendorSales->has($vendorId)) {
                     $vendorSales->put($vendorId, [
                         'id' => $vendorId,
-                        'name' => $vendorName,
+                        'name' => $lineItem['vendor_name'],
                         'count' => 0,
                         'amount' => 0,
                         'commission_percent' => $commissionPercent,
@@ -1261,10 +1442,9 @@ class PosSessionsTable
                 }
 
                 $current = $vendorSales->get($vendorId);
-                $current['count'] += $quantity;
+                $current['count'] += (float) $lineItem['quantity'];
                 $current['amount'] += $lineTotal;
 
-                // Calculate commission if commission_percent is set
                 if ($commissionPercent !== null && $commissionPercent > 0) {
                     $commissionAmount = (int) round($lineTotal * ($commissionPercent / 100));
                     $current['commission_amount'] += $commissionAmount;

--- a/app/Filament/Resources/PosSessions/Tables/PosSessionsTable.php
+++ b/app/Filament/Resources/PosSessions/Tables/PosSessionsTable.php
@@ -1002,8 +1002,13 @@ class PosSessionsTable
             return $lineItems;
         }
 
-        $indices = array_keys($lineItems);
-        $lastIndex = end($indices);
+        $lastPositiveIndex = null;
+        foreach ($lineItems as $index => $lineItem) {
+            if ($lineItem['net_before_cart_discount'] > 0) {
+                $lastPositiveIndex = $index;
+            }
+        }
+
         $allocated = 0;
 
         foreach ($lineItems as $index => &$lineItem) {
@@ -1015,7 +1020,7 @@ class PosSessionsTable
                 continue;
             }
 
-            if ($index === $lastIndex) {
+            if ($index === $lastPositiveIndex) {
                 $cartShare = $remainingCartDiscount - $allocated;
             } else {
                 $cartShare = (int) floor(($remainingCartDiscount * $base) / $discountableBase);

--- a/app/Filament/Widgets/TopProductsWidget.php
+++ b/app/Filament/Widgets/TopProductsWidget.php
@@ -26,6 +26,63 @@ class TopProductsWidget extends ChartWidget
         return 'Top Products';
     }
 
+    /**
+     * Parse item amount to øre.
+     */
+    protected function parseAmountToOre(mixed $value): int
+    {
+        if (is_string($value)) {
+            $hasFormatting = str_contains($value, ',')
+                || str_contains($value, ' ')
+                || (str_contains($value, '.') && preg_match('/\.\d{2}$/', $value));
+
+            if ($hasFormatting) {
+                $cleaned = str_replace([' ', ','], ['', '.'], $value);
+                $cleaned = preg_replace('/[^\d.]/', '', $cleaned);
+                if ($cleaned === '' || $cleaned === null) {
+                    return 0;
+                }
+
+                return (int) round((float) $cleaned * 100);
+            }
+
+            return (int) round((float) $value);
+        }
+
+        if (is_numeric($value)) {
+            return (int) round((float) $value);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Resolve total cart discounts in øre.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    protected function resolveTotalDiscountsOre(array $metadata): int
+    {
+        if (isset($metadata['total_discounts']) && is_numeric($metadata['total_discounts'])) {
+            return max(0, (int) $metadata['total_discounts']);
+        }
+
+        $discounts = $metadata['discounts'] ?? [];
+        if (! is_array($discounts)) {
+            return 0;
+        }
+
+        $sum = 0;
+        foreach ($discounts as $discount) {
+            if (! is_array($discount)) {
+                continue;
+            }
+            $sum += max(0, $this->parseAmountToOre($discount['amount'] ?? 0));
+        }
+
+        return $sum;
+    }
+
     protected function getData(): array
     {
         $store = Filament::getTenant();
@@ -55,14 +112,17 @@ class TopProductsWidget extends ChartWidget
         foreach ($charges as $charge) {
             $metadata = $charge->metadata ?? [];
             $items = $metadata['items'] ?? [];
+            $lineEntries = [];
+            $itemDiscountsTotalOre = 0;
+            $netBeforeCartDiscountTotalOre = 0;
 
-            $lineTotalsByIndex = [];
-            $lineTotalsSumOre = 0;
+            foreach ($items as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
 
-            foreach ($items as $index => $item) {
                 $quantity = isset($item['quantity']) ? (float) $item['quantity'] : 1.0;
                 $unitPriceOre = (int) ($item['unit_price'] ?? $item['price'] ?? 0);
-
                 $lineTotalOre = (int) round($unitPriceOre * $quantity);
 
                 if (isset($item['line_total_amount']) && is_numeric($item['line_total_amount'])) {
@@ -72,21 +132,65 @@ class TopProductsWidget extends ChartWidget
                 }
 
                 $lineTotalOre = max(0, $lineTotalOre);
-                $lineTotalsByIndex[$index] = $lineTotalOre;
-                $lineTotalsSumOre += $lineTotalOre;
+
+                $itemDiscountOre = 0;
+                if (isset($item['discount_total_amount']) && is_numeric($item['discount_total_amount'])) {
+                    $itemDiscountOre = max(0, (int) round((float) $item['discount_total_amount']));
+                } elseif (isset($item['discount_amount'])) {
+                    $discountPerUnitOre = $this->parseAmountToOre($item['discount_amount']);
+                    $itemDiscountOre = (int) round($discountPerUnitOre * $quantity);
+                }
+
+                $itemDiscountOre = min($itemDiscountOre, $lineTotalOre);
+                $lineNetBeforeCartDiscountOre = max(0, $lineTotalOre - $itemDiscountOre);
+
+                $lineEntries[] = [
+                    'item' => $item,
+                    'quantity' => $quantity,
+                    'line_net_ore' => $lineNetBeforeCartDiscountOre,
+                ];
+
+                $itemDiscountsTotalOre += $itemDiscountOre;
+                $netBeforeCartDiscountTotalOre += $lineNetBeforeCartDiscountOre;
             }
 
-            $chargeAmountOre = max(0, (int) $charge->amount - (int) ($charge->tip_amount ?? 0));
-            $allocationRatio = $lineTotalsSumOre > 0
-                ? min(1, $chargeAmountOre / $lineTotalsSumOre)
-                : 1;
+            $totalDiscountsOre = $this->resolveTotalDiscountsOre(is_array($metadata) ? $metadata : []);
+            $remainingCartDiscountOre = max(0, $totalDiscountsOre - $itemDiscountsTotalOre);
 
-            foreach ($items as $index => $item) {
+            if ($remainingCartDiscountOre > 0 && $netBeforeCartDiscountTotalOre > 0) {
+                $allocated = 0;
+                $lastIndex = count($lineEntries) - 1;
+
+                foreach ($lineEntries as $index => &$entry) {
+                    $base = $entry['line_net_ore'];
+                    if ($base <= 0) {
+                        continue;
+                    }
+
+                    if ($index === $lastIndex) {
+                        $cartShare = $remainingCartDiscountOre - $allocated;
+                    } else {
+                        $cartShare = (int) floor(($remainingCartDiscountOre * $base) / $netBeforeCartDiscountTotalOre);
+                        $allocated += $cartShare;
+                    }
+
+                    $entry['line_net_ore'] = max(0, $base - $cartShare);
+                }
+                unset($entry);
+            }
+
+            $lineNetTotalOre = array_sum(array_column($lineEntries, 'line_net_ore'));
+            $chargeAmountOre = max(0, (int) $charge->amount - (int) ($charge->tip_amount ?? 0));
+            $allocationRatio = $lineNetTotalOre > 0
+                ? min(1, $chargeAmountOre / $lineNetTotalOre)
+                : 1.0;
+
+            foreach ($lineEntries as $entry) {
+                $item = $entry['item'];
                 $productId = $item['product_id'] ?? $item['stripe_product_id'] ?? null;
                 $productName = $item['name'] ?? $item['product_name'] ?? 'Unknown Product';
-                $quantity = $item['quantity'] ?? 1;
-                $lineTotalOre = $lineTotalsByIndex[$index] ?? 0;
-                $paidLineTotalOre = $lineTotalOre * $allocationRatio;
+                $quantity = $entry['quantity'];
+                $paidLineTotalOre = $entry['line_net_ore'] * $allocationRatio;
 
                 if ($productId || $productName !== 'Unknown Product') {
                     $key = $productId ?: $productName;

--- a/app/Filament/Widgets/TopProductsWidget.php
+++ b/app/Filament/Widgets/TopProductsWidget.php
@@ -158,8 +158,14 @@ class TopProductsWidget extends ChartWidget
             $remainingCartDiscountOre = max(0, $totalDiscountsOre - $itemDiscountsTotalOre);
 
             if ($remainingCartDiscountOre > 0 && $netBeforeCartDiscountTotalOre > 0) {
+                $lastPositiveIndex = null;
+                foreach ($lineEntries as $index => $entry) {
+                    if ($entry['line_net_ore'] > 0) {
+                        $lastPositiveIndex = $index;
+                    }
+                }
+
                 $allocated = 0;
-                $lastIndex = count($lineEntries) - 1;
 
                 foreach ($lineEntries as $index => &$entry) {
                     $base = $entry['line_net_ore'];
@@ -167,7 +173,7 @@ class TopProductsWidget extends ChartWidget
                         continue;
                     }
 
-                    if ($index === $lastIndex) {
+                    if ($index === $lastPositiveIndex) {
                         $cartShare = $remainingCartDiscountOre - $allocated;
                     } else {
                         $cartShare = (int) floor(($remainingCartDiscountOre * $base) / $netBeforeCartDiscountTotalOre);

--- a/app/Filament/Widgets/TopProductsWidget.php
+++ b/app/Filament/Widgets/TopProductsWidget.php
@@ -6,7 +6,6 @@ use App\Filament\Widgets\Concerns\HasDashboardDateRange;
 use App\Models\ConnectedCharge;
 use Filament\Facades\Filament;
 use Filament\Widgets\ChartWidget;
-use Illuminate\Support\Carbon;
 
 class TopProductsWidget extends ChartWidget
 {
@@ -14,7 +13,7 @@ class TopProductsWidget extends ChartWidget
 
     protected static ?int $sort = 7;
 
-    protected int | string | array $columnSpan = [
+    protected int|string|array $columnSpan = [
         'default' => 'full',
         'sm' => 'full',
         'md' => 'full',
@@ -24,14 +23,14 @@ class TopProductsWidget extends ChartWidget
 
     public function getHeading(): string
     {
-        return "Top Products";
+        return 'Top Products';
     }
 
     protected function getData(): array
     {
         $store = Filament::getTenant();
-        
-        if (!$store) {
+
+        if (! $store) {
             return [
                 'datasets' => [],
                 'labels' => [],
@@ -52,36 +51,57 @@ class TopProductsWidget extends ChartWidget
 
         // Aggregate products from charge metadata
         $productStats = [];
-        
+
         foreach ($charges as $charge) {
             $metadata = $charge->metadata ?? [];
             $items = $metadata['items'] ?? [];
-            
-            foreach ($items as $item) {
+
+            $lineTotalsByIndex = [];
+            $lineTotalsSumOre = 0;
+
+            foreach ($items as $index => $item) {
+                $quantity = isset($item['quantity']) ? (float) $item['quantity'] : 1.0;
+                $unitPriceOre = (int) ($item['unit_price'] ?? $item['price'] ?? 0);
+
+                $lineTotalOre = (int) round($unitPriceOre * $quantity);
+
+                if (isset($item['line_total_amount']) && is_numeric($item['line_total_amount'])) {
+                    $lineTotalOre = (int) round((float) $item['line_total_amount']);
+                } elseif (isset($item['line_total']) && is_numeric($item['line_total'])) {
+                    $lineTotalOre = (int) round((float) $item['line_total']);
+                }
+
+                $lineTotalOre = max(0, $lineTotalOre);
+                $lineTotalsByIndex[$index] = $lineTotalOre;
+                $lineTotalsSumOre += $lineTotalOre;
+            }
+
+            $chargeAmountOre = max(0, (int) $charge->amount - (int) ($charge->tip_amount ?? 0));
+            $allocationRatio = $lineTotalsSumOre > 0
+                ? min(1, $chargeAmountOre / $lineTotalsSumOre)
+                : 1;
+
+            foreach ($items as $index => $item) {
                 $productId = $item['product_id'] ?? $item['stripe_product_id'] ?? null;
                 $productName = $item['name'] ?? $item['product_name'] ?? 'Unknown Product';
                 $quantity = $item['quantity'] ?? 1;
-                
-                // Prices in metadata are stored in øre (cents), convert to kroner
-                $unitPrice = $item['unit_price'] ?? $item['price'] ?? 0;
-                $price = $unitPrice / 100; // Convert from øre to kroner
-                
-                $lineTotal = $price * $quantity;
-                
+                $lineTotalOre = $lineTotalsByIndex[$index] ?? 0;
+                $paidLineTotalOre = $lineTotalOre * $allocationRatio;
+
                 if ($productId || $productName !== 'Unknown Product') {
                     $key = $productId ?: $productName;
-                    
-                    if (!isset($productStats[$key])) {
+
+                    if (! isset($productStats[$key])) {
                         $productStats[$key] = [
                             'name' => $productName,
                             'quantity' => 0,
-                            'revenue' => 0,
+                            'revenue_ore' => 0.0,
                             'transactions' => 0,
                         ];
                     }
-                    
+
                     $productStats[$key]['quantity'] += $quantity;
-                    $productStats[$key]['revenue'] += $lineTotal;
+                    $productStats[$key]['revenue_ore'] += $paidLineTotalOre;
                     $productStats[$key]['transactions'] += 1;
                 }
             }
@@ -89,9 +109,9 @@ class TopProductsWidget extends ChartWidget
 
         // Sort by revenue and take top 10
         usort($productStats, function ($a, $b) {
-            return $b['revenue'] <=> $a['revenue'];
+            return $b['revenue_ore'] <=> $a['revenue_ore'];
         });
-        
+
         $topProducts = array_slice($productStats, 0, 10);
 
         if (empty($topProducts)) {
@@ -102,9 +122,9 @@ class TopProductsWidget extends ChartWidget
         }
 
         // Prepare data for chart
-        $labels = array_map(fn($product) => $product['name'], $topProducts);
-        $revenues = array_map(fn($product) => round($product['revenue'], 2), $topProducts);
-        $quantities = array_map(fn($product) => $product['quantity'], $topProducts);
+        $labels = array_map(fn ($product) => $product['name'], $topProducts);
+        $revenues = array_map(fn ($product) => round($product['revenue_ore'] / 100, 2), $topProducts);
+        $quantities = array_map(fn ($product) => $product['quantity'], $topProducts);
 
         return [
             'datasets' => [
@@ -165,4 +185,3 @@ class TopProductsWidget extends ChartWidget
         ];
     }
 }
-

--- a/app/Http/Controllers/Api/PurchasesController.php
+++ b/app/Http/Controllers/Api/PurchasesController.php
@@ -745,19 +745,118 @@ class PurchasesController extends BaseApiController
             return [];
         }
 
-        $arrayItems = array_filter($items, fn ($item) => is_array($item));
+        $arrayItems = array_values(array_filter($items, fn ($item) => is_array($item)));
+        $totalDiscountsOre = $this->resolveTotalDiscountsOreFromMetadata(is_array($metadata) ? $metadata : []);
 
-        return array_values(array_map(function (array $item): array {
+        $lineItems = [];
+        $itemDiscountsTotalOre = 0;
+        $netBeforeCartDiscountTotalOre = 0;
+
+        foreach ($arrayItems as $item) {
             $quantity = isset($item['quantity']) ? (float) $item['quantity'] : 1.0;
             $unitPrice = isset($item['unit_price']) ? (int) $item['unit_price'] : 0;
+            $lineTotalOre = (int) round($unitPrice * $quantity);
 
-            return [
+            $itemDiscountOre = 0;
+            if (isset($item['discount_total_amount'])) {
+                $itemDiscountOre = max(0, $this->parseDiscountAmountToOre($item['discount_total_amount']));
+            } elseif (isset($item['discount_amount'])) {
+                $discountPerUnitOre = max(0, $this->parseDiscountAmountToOre($item['discount_amount']));
+                $itemDiscountOre = (int) round($discountPerUnitOre * $quantity);
+            }
+
+            $itemDiscountOre = min($itemDiscountOre, $lineTotalOre);
+            $lineNetBeforeCartDiscountOre = max(0, $lineTotalOre - $itemDiscountOre);
+
+            $lineItems[] = [
                 'product_name' => (string) ($item['product_name'] ?? $item['description'] ?? 'Ukjent produkt'),
                 'quantity' => $quantity,
                 'unit_price_ore' => $unitPrice,
-                'line_total_ore' => (int) round($unitPrice * $quantity),
+                'line_total_ore' => $lineNetBeforeCartDiscountOre,
             ];
-        }, $arrayItems));
+
+            $itemDiscountsTotalOre += $itemDiscountOre;
+            $netBeforeCartDiscountTotalOre += $lineNetBeforeCartDiscountOre;
+        }
+
+        $remainingCartDiscountOre = max(0, $totalDiscountsOre - $itemDiscountsTotalOre);
+        if ($remainingCartDiscountOre > 0 && $netBeforeCartDiscountTotalOre > 0) {
+            $allocated = 0;
+            $lastIndex = count($lineItems) - 1;
+
+            foreach ($lineItems as $index => &$lineItem) {
+                $base = (int) ($lineItem['line_total_ore'] ?? 0);
+                if ($base <= 0) {
+                    continue;
+                }
+
+                if ($index === $lastIndex) {
+                    $cartShare = $remainingCartDiscountOre - $allocated;
+                } else {
+                    $cartShare = (int) floor(($remainingCartDiscountOre * $base) / $netBeforeCartDiscountTotalOre);
+                    $allocated += $cartShare;
+                }
+
+                $lineItem['line_total_ore'] = max(0, $base - $cartShare);
+            }
+            unset($lineItem);
+        }
+
+        return $lineItems;
+    }
+
+    /**
+     * Parse discount amount value to øre.
+     */
+    protected function parseDiscountAmountToOre(mixed $value): int
+    {
+        if (is_string($value)) {
+            $hasFormatting = strpos($value, ',') !== false
+                || strpos($value, ' ') !== false
+                || (strpos($value, '.') !== false && preg_match('/\.\d{2}$/', $value));
+
+            if ($hasFormatting) {
+                $cleaned = str_replace([' ', ','], ['', '.'], $value);
+                $cleaned = preg_replace('/[^\d.]/', '', $cleaned);
+
+                return (int) round((float) $cleaned * 100);
+            }
+
+            return (int) round((float) $value);
+        }
+
+        if (is_numeric($value)) {
+            return (int) round((float) $value);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Resolve total discounts in øre from charge metadata.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    protected function resolveTotalDiscountsOreFromMetadata(array $metadata): int
+    {
+        if (isset($metadata['total_discounts']) && is_numeric($metadata['total_discounts'])) {
+            return max(0, (int) $metadata['total_discounts']);
+        }
+
+        $discounts = $metadata['discounts'] ?? [];
+        if (! is_array($discounts)) {
+            return 0;
+        }
+
+        $sum = 0;
+        foreach ($discounts as $discount) {
+            if (! is_array($discount)) {
+                continue;
+            }
+            $sum += max(0, $this->parseDiscountAmountToOre($discount['amount'] ?? 0));
+        }
+
+        return $sum;
     }
 
     /**

--- a/app/Http/Controllers/Api/PurchasesController.php
+++ b/app/Http/Controllers/Api/PurchasesController.php
@@ -781,8 +781,14 @@ class PurchasesController extends BaseApiController
 
         $remainingCartDiscountOre = max(0, $totalDiscountsOre - $itemDiscountsTotalOre);
         if ($remainingCartDiscountOre > 0 && $netBeforeCartDiscountTotalOre > 0) {
+            $lastPositiveIndex = null;
+            foreach ($lineItems as $index => $lineItem) {
+                if ((int) ($lineItem['line_total_ore'] ?? 0) > 0) {
+                    $lastPositiveIndex = $index;
+                }
+            }
+
             $allocated = 0;
-            $lastIndex = count($lineItems) - 1;
 
             foreach ($lineItems as $index => &$lineItem) {
                 $base = (int) ($lineItem['line_total_ore'] ?? 0);
@@ -790,7 +796,7 @@ class PurchasesController extends BaseApiController
                     continue;
                 }
 
-                if ($index === $lastIndex) {
+                if ($index === $lastPositiveIndex) {
                     $cartShare = $remainingCartDiscountOre - $allocated;
                 } else {
                     $cartShare = (int) floor(($remainingCartDiscountOre * $base) / $netBeforeCartDiscountTotalOre);

--- a/tests/Feature/DiscountReportingTest.php
+++ b/tests/Feature/DiscountReportingTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Filament\Resources\PosPurchases\Schemas\PosPurchaseInfolist;
+use App\Filament\Resources\PosSessions\Tables\PosSessionsTable;
+use App\Models\ConnectedCharge;
+use App\Models\ConnectedProduct;
+use App\Models\PosDevice;
+use App\Models\PosSession;
+use App\Models\Receipt;
+use App\Models\Store;
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('uses net amounts for z-report product and vendor aggregates when discounts exist', function () {
+    $store = Store::factory()->create([
+        'stripe_account_id' => 'acct_test_discount_aggregation',
+    ]);
+    $user = User::factory()->create();
+    $device = PosDevice::factory()->create(['store_id' => $store->id]);
+    $session = PosSession::factory()->create([
+        'store_id' => $store->id,
+        'pos_device_id' => $device->id,
+        'user_id' => $user->id,
+        'status' => 'closed',
+        'opened_at' => now()->subHour(),
+        'closed_at' => now(),
+    ]);
+
+    $vendor = Vendor::create([
+        'store_id' => $store->id,
+        'stripe_account_id' => $store->stripe_account_id,
+        'name' => 'Discount Vendor',
+        'active' => true,
+        'commission_percent' => 10,
+    ]);
+
+    $product = ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'vendor_id' => $vendor->id,
+        'name' => 'Freeticket Product',
+    ]);
+
+    $charge = ConnectedCharge::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'pos_session_id' => $session->id,
+        'amount' => 0,
+        'status' => 'succeeded',
+        'paid' => true,
+        'paid_at' => now(),
+        'payment_method' => 'freeticket',
+        'metadata' => [
+            'items' => [
+                [
+                    'product_id' => $product->id,
+                    'quantity' => 1,
+                    'unit_price' => 198000,
+                ],
+            ],
+            'total_discounts' => 198000,
+            'subtotal' => 198000,
+            'total' => 0,
+        ],
+    ]);
+
+    Receipt::factory()->create([
+        'store_id' => $store->id,
+        'pos_session_id' => $session->id,
+        'charge_id' => $charge->id,
+        'receipt_type' => 'sales',
+        'receipt_data' => [
+            'items' => [
+                [
+                    'name' => 'Freeticket Product',
+                    'product_id' => $product->id,
+                    'quantity' => 1,
+                    'unit_price' => 198000,
+                ],
+            ],
+            'total_discounts' => 198000,
+            'subtotal' => 198000,
+            'total' => 0,
+        ],
+    ]);
+
+    $report = PosSessionsTable::generateZReport($session, attachMissingData: false);
+
+    expect($report['products_sold'])->not->toBeEmpty();
+    expect($report['products_sold'][0]['amount'])->toBe(0);
+    expect($report['sales_by_vendor'])->not->toBeEmpty();
+    expect($report['sales_by_vendor'][0]['amount'])->toBe(0);
+    expect($report['sales_by_vendor'][0]['commission_amount'])->toBe(0);
+});
+
+it('derives purchase discounts for filament infolist from subtotal minus total when metadata total_discounts is missing', function () {
+    $record = new class
+    {
+        public array $metadata = [
+            'items' => [
+                [
+                    'quantity' => 1,
+                    'unit_price' => 198000,
+                ],
+            ],
+            'subtotal' => 198000,
+            'total' => 0,
+        ];
+
+        public int $amount = 0;
+    };
+
+    expect(PosPurchaseInfolist::resolveTotalDiscountsOreForDisplay($record))->toBe(198000);
+});

--- a/tests/Feature/PurchasesApiTest.php
+++ b/tests/Feature/PurchasesApiTest.php
@@ -249,6 +249,54 @@ test('kiosk sales report returns only kiosk purchases in date range', function (
     $response->assertJsonPath('data.0.is_refund', false);
 });
 
+test('kiosk sales report items include net line totals after discounts', function () {
+    $user = User::factory()->create();
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_test_kiosk_item_discounts']);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    $posDevice = PosDevice::factory()->create(['store_id' => $store->id]);
+    $session = PosSession::factory()->create([
+        'store_id' => $store->id,
+        'pos_device_id' => $posDevice->id,
+        'user_id' => $user->id,
+        'status' => 'open',
+    ]);
+
+    $kioskCharge = ConnectedCharge::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'pos_session_id' => $session->id,
+        'paid' => true,
+        'status' => 'succeeded',
+        'amount' => 5000,
+        'amount_refunded' => 0,
+        'paid_at' => '2026-03-13 09:30:00',
+        'metadata' => [
+            'items' => [
+                [
+                    'id' => 'item_kiosk_discounted',
+                    'name' => 'Kaffe',
+                    'quantity' => 1,
+                    'unit_price' => 10000,
+                    'discount_amount' => 5000,
+                ],
+            ],
+            'total_discounts' => 5000,
+            'total' => 5000,
+        ],
+    ]);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->getJson('/api/reports/kiosk-sales?from_datetime=2026-03-13T00:00:00Z&to_datetime=2026-03-13T23:59:59Z&limit=50');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.purchase_id', $kioskCharge->id);
+    $response->assertJsonPath('data.0.net_amount_ore', 5000);
+    $response->assertJsonPath('data.0.items.0.line_total_ore', 5000);
+});
+
 test('kiosk sales report supports cursor and updated_since filters', function () {
     $user = User::factory()->create();
     $store = Store::factory()->create(['stripe_account_id' => 'acct_test_kiosk_cursor']);

--- a/tests/Feature/TopProductsWidgetTest.php
+++ b/tests/Feature/TopProductsWidgetTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Filament\Widgets\TopProductsWidget;
+use App\Models\ConnectedCharge;
+use App\Models\PosSession;
+use App\Models\Store;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('it allocates cart level discounts to product revenue', function () {
+    $store = Store::factory()->create([
+        'stripe_account_id' => 'acct_top_products_discounts',
+    ]);
+
+    $session = PosSession::factory()->create([
+        'store_id' => $store->id,
+    ]);
+
+    ConnectedCharge::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'pos_session_id' => $session->id,
+        'status' => 'succeeded',
+        'paid_at' => now(),
+        'amount' => 15000,
+        'metadata' => [
+            'items' => [
+                [
+                    'product_id' => 1,
+                    'name' => 'Product A',
+                    'quantity' => 1,
+                    'unit_price' => 10000,
+                ],
+                [
+                    'product_id' => 2,
+                    'name' => 'Product B',
+                    'quantity' => 1,
+                    'unit_price' => 10000,
+                ],
+            ],
+            'total' => 15000,
+            'total_discounts' => 5000,
+        ],
+    ]);
+
+    Filament::shouldReceive('getTenant')
+        ->once()
+        ->andReturn($store);
+
+    $widget = new class extends TopProductsWidget
+    {
+        public function exposedData(): array
+        {
+            return $this->getData();
+        }
+    };
+
+    $data = $widget->exposedData();
+    $revenueByLabel = array_combine($data['labels'], $data['datasets'][0]['data']);
+
+    expect($revenueByLabel)
+        ->toHaveKey('Product A')
+        ->toHaveKey('Product B');
+
+    expect($revenueByLabel['Product A'])->toBe(75.0)
+        ->and($revenueByLabel['Product B'])->toBe(75.0);
+});

--- a/tests/Feature/TopProductsWidgetTest.php
+++ b/tests/Feature/TopProductsWidgetTest.php
@@ -24,6 +24,7 @@ test('it allocates cart level discounts to product revenue', function () {
         'status' => 'succeeded',
         'paid_at' => now(),
         'amount' => 15000,
+        'tip_amount' => 0,
         'metadata' => [
             'items' => [
                 [
@@ -65,4 +66,60 @@ test('it allocates cart level discounts to product revenue', function () {
 
     expect($revenueByLabel['Product A'])->toBe(75.0)
         ->and($revenueByLabel['Product B'])->toBe(75.0);
+});
+
+test('it applies item-level discounts to the discounted product only', function () {
+    $store = Store::factory()->create([
+        'stripe_account_id' => 'acct_top_products_item_discount',
+    ]);
+
+    $session = PosSession::factory()->create([
+        'store_id' => $store->id,
+    ]);
+
+    ConnectedCharge::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'pos_session_id' => $session->id,
+        'status' => 'succeeded',
+        'paid_at' => now(),
+        'amount' => 15000,
+        'tip_amount' => 0,
+        'metadata' => [
+            'items' => [
+                [
+                    'product_id' => 11,
+                    'name' => 'Product A',
+                    'quantity' => 1,
+                    'unit_price' => 10000,
+                    'discount_amount' => 5000,
+                ],
+                [
+                    'product_id' => 12,
+                    'name' => 'Product B',
+                    'quantity' => 1,
+                    'unit_price' => 10000,
+                ],
+            ],
+            'total' => 15000,
+            'total_discounts' => 5000,
+        ],
+    ]);
+
+    Filament::shouldReceive('getTenant')
+        ->once()
+        ->andReturn($store);
+
+    $widget = new class extends TopProductsWidget
+    {
+        public function exposedData(): array
+        {
+            return $this->getData();
+        }
+    };
+
+    $data = $widget->exposedData();
+    $revenueByLabel = array_combine($data['labels'], $data['datasets'][0]['data']);
+
+    expect($revenueByLabel['Product A'])->toBe(50.0)
+        ->and($revenueByLabel['Product B'])->toBe(100.0);
 });


### PR DESCRIPTION
## Summary
- ensure purchase infolist discount display falls back to item-level and subtotal-total derived values when `total_discounts` is missing
- apply item-level and cart-level discounts when calculating Z-report product and vendor totals, so reported sales use net paid amounts
- update top-products widget revenue allocation to use paid charge amount proportions and add a `stripe:sync-charges` artisan command for connected-account charge sync

## Test plan
- [x] `php artisan test --compact tests/Feature/DiscountReportingTest.php tests/Feature/TopProductsWidgetTest.php`
- [x] `vendor/bin/pint --dirty --format agent`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches financial reporting calculations (discount allocation across line items and aggregates) and adds a new Stripe sync CLI path; mistakes could skew reported revenue/commissions or update charge records incorrectly.
> 
> **Overview**
> **Discount-aware reporting:** Updates POS purchase and reporting views to compute *net* line totals by applying item-level discounts and allocating remaining cart-level discounts proportionally (with fallback parsing of `total_discounts` / `discounts` arrays and subtotal-vs-total derivation). This changes Z-report product/vendor aggregates, kiosk-sales API item totals, and the `TopProductsWidget` revenue calculation to reflect net paid amounts (excluding tips) rather than pre-discount totals.
> 
> **Ops tooling:** Adds `stripe:sync-charges` to sync Stripe connected-account charges into `ConnectedCharge` records for a single store or all stores with Stripe accounts, with per-store and overall summaries.
> 
> **Tests:** Adds feature tests covering discount allocation for Z-reports, purchase infolist discount fallback behavior, kiosk-sales line totals, and top-products revenue allocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ca0b0465a88347a57925197f01dcc2931e9d49e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->