### PR TITLE
Fix global roles and tenant access consistency

### DIFF
--- a/app/Filament/Resources/Shield/Roles/RoleResource.php
+++ b/app/Filament/Resources/Shield/Roles/RoleResource.php
@@ -13,8 +13,6 @@ use BezhanSalleh\PluginEssentials\Concerns\Resource as Essentials;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
-use Filament\Facades\Filament;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Panel;
 use Filament\Resources\Resource;
@@ -25,11 +23,11 @@ use Filament\Support\Enums\FontWeight;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Unique;
 
 class RoleResource extends Resource
 {
     use Essentials\BelongsToParent;
+
     // Removed BelongsToTenant to prevent tenant scoping for roles
     use Essentials\HasGlobalSearch;
     use Essentials\HasLabels;
@@ -63,10 +61,7 @@ class RoleResource extends Resource
                             ->schema([
                                 TextInput::make('name')
                                     ->label(__('filament-shield::filament-shield.field.name'))
-                                    ->unique(
-                                        ignoreRecord: true,
-                                        modifyRuleUsing: fn (Unique $rule): Unique => Utils::isTenancyEnabled() ? $rule->where(Utils::getTenantModelForeignKey(), Filament::getTenant()?->id) : $rule
-                                    )
+                                    ->unique(ignoreRecord: true)
                                     ->required()
                                     ->maxLength(255),
 
@@ -75,14 +70,6 @@ class RoleResource extends Resource
                                     ->default(Utils::getFilamentAuthGuard())
                                     ->nullable()
                                     ->maxLength(255),
-
-                                Select::make(config('permission.column_names.team_foreign_key'))
-                                    ->label(__('filament-shield::filament-shield.field.team'))
-                                    ->placeholder(__('filament-shield::filament-shield.field.team.placeholder'))
-                                    ->default(Filament::getTenant()?->id)
-                                    ->options(fn (): array => in_array(Utils::getTenantModel(), [null, '', '0'], true) ? [] : Utils::getTenantModel()::pluck('name', 'id')->toArray())
-                                    ->visible(fn (): bool => static::shield()->isCentralApp() && Utils::isTenancyEnabled())
-                                    ->dehydrated(fn (): bool => static::shield()->isCentralApp() && Utils::isTenancyEnabled()),
                                 static::getSelectAllFormComponent(),
 
                             ])
@@ -110,13 +97,6 @@ class RoleResource extends Resource
                     ->badge()
                     ->color('warning')
                     ->label(__('filament-shield::filament-shield.column.guard_name')),
-                TextColumn::make('team.name')
-                    ->default('Global')
-                    ->badge()
-                    ->color(fn (mixed $state): string => str($state)->contains('Global') ? 'gray' : 'primary')
-                    ->label(__('filament-shield::filament-shield.column.team'))
-                    ->searchable()
-                    ->visible(fn (): bool => static::shield()->isCentralApp() && Utils::isTenancyEnabled()),
                 TextColumn::make('permissions_count')
                     ->badge()
                     ->label(__('filament-shield::filament-shield.column.permissions'))
@@ -180,4 +160,3 @@ class RoleResource extends Resource
         return __('filament.navigation_groups.administration');
     }
 }
-

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -2,13 +2,11 @@
 
 namespace App\Filament\Resources\Users\Schemas;
 
-use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\View;
-use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Hash;
@@ -53,12 +51,16 @@ class UserForm
 
                 Select::make('roles')
                     ->label('Roles')
-                    ->relationship('roles', 'name')
+                    ->relationship(
+                        'roles',
+                        'name',
+                        modifyQueryUsing: fn ($query) => $query->withoutGlobalScopes()->orderBy('name')
+                    )
                     ->multiple()
                     ->preload()
                     ->searchable()
                     ->helperText('Assign roles to the user. Super admins have access to all stores.'),
-                
+
                 Section::make('Active API Tokens')
                     ->schema([
                         View::make('filament.resources.users.components.api-tokens')

--- a/app/Http/Controllers/Api/BaseApiController.php
+++ b/app/Http/Controllers/Api/BaseApiController.php
@@ -71,7 +71,15 @@ abstract class BaseApiController extends BaseController
 
         $user = $request->user();
 
-        if (! $user || ! $user->stores->contains($tenant)) {
+        if (! $user) {
+            abort(403, 'You do not have access to this tenant.');
+        }
+
+        if ($user->hasGlobalSuperAdminRole()) {
+            return;
+        }
+
+        if (! $user->stores->contains($tenant)) {
             abort(403, 'You do not have access to this tenant.');
         }
     }

--- a/app/Http/Controllers/Api/StoreController.php
+++ b/app/Http/Controllers/Api/StoreController.php
@@ -47,7 +47,7 @@ class StoreController extends BaseApiController
         $user = $request->user();
 
         // Super admins can see all stores
-        if ($user->hasRole('super_admin')) {
+        if ($user->hasGlobalSuperAdminRole()) {
             $stores = Store::with('settings')->get();
         } else {
             $stores = $user->stores->load('settings');
@@ -84,7 +84,7 @@ class StoreController extends BaseApiController
         }
 
         // Check if user has access to this store
-        if (! $user->hasRole('super_admin') && ! $user->stores->contains($store)) {
+        if (! $user->hasGlobalSuperAdminRole() && ! $user->stores->contains($store)) {
             return response()->json([
                 'message' => 'You do not have access to this store',
             ], 403);
@@ -144,7 +144,7 @@ class StoreController extends BaseApiController
         }
 
         // Verify user has access to this store
-        if (! $user->hasRole('super_admin') && ! $user->stores->contains($store)) {
+        if (! $user->hasGlobalSuperAdminRole() && ! $user->stores->contains($store)) {
             return response()->json([
                 'message' => 'You do not have access to this store',
             ], 403);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,6 +109,11 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     public function currentStore(): ?Store
     {
         if ($this->current_store_id) {
+            // Super admins can access any store
+            if ($this->isSuperAdmin()) {
+                return Store::find($this->current_store_id);
+            }
+
             return $this->stores()->where('stores.id', $this->current_store_id)->first();
         }
 
@@ -121,8 +126,8 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
      */
     public function setCurrentStore(Store $store): bool
     {
-        // Verify user has access to this store
-        if (! $this->stores->contains($store)) {
+        // Super admins can set any store as current
+        if (! $this->isSuperAdmin() && ! $this->stores->contains($store)) {
             return false;
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -142,22 +142,24 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     }
 
     /**
-     * Check if user is a super admin, bypassing tenant scoping
+     * Check whether the user has the global super admin role.
      */
-    protected function isSuperAdmin(): bool
+    public function isSuperAdmin(): bool
     {
-        try {
-            // Use withoutGlobalScopes to bypass tenant scoping for role checks
-            $tenant = \Filament\Facades\Filament::getTenant();
-            if ($tenant) {
-                return $this->roles()->withoutGlobalScopes()->where('name', 'super_admin')->exists();
-            }
+        return $this->hasGlobalSuperAdminRole();
+    }
 
-            return $this->hasRole('super_admin');
-        } catch (\Throwable $e) {
-            // Fallback to regular check if Filament facade is not available
-            return $this->hasRole('super_admin');
-        }
+    /**
+     * Resolve global super-admin status without tenant-scoped role queries.
+     */
+    public function hasGlobalSuperAdminRole(): bool
+    {
+        $superAdminRoleName = (string) config('filament-shield.super_admin.name', 'super_admin');
+
+        return $this->roles()
+            ->withoutGlobalScopes()
+            ->where('name', $superAdminRoleName)
+            ->exists();
     }
 
     public function getDefaultTenant(Panel $panel): ?Model

--- a/tests/Feature/Tenancy/GlobalRolesTenantAccessTest.php
+++ b/tests/Feature/Tenancy/GlobalRolesTenantAccessTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\Store;
+use App\Models\User;
+use BezhanSalleh\FilamentShield\Resources\Roles\Pages\CreateRole;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+use function Pest\Livewire\livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->store = Store::factory()->create([
+        'slug' => 'tenant-store',
+    ]);
+});
+
+it('can load the role create page in tenant context', function (): void {
+    $role = Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+
+    Permission::firstOrCreate(['name' => 'Create:Role', 'guard_name' => 'web']);
+    Permission::firstOrCreate(['name' => 'ViewAny:Role', 'guard_name' => 'web']);
+
+    $role->givePermissionTo(['Create:Role', 'ViewAny:Role']);
+
+    $user = User::factory()->create();
+    $user->stores()->attach($this->store);
+    $user->assignRole('super_admin');
+
+    $this->actingAs($user);
+    Filament::setTenant($this->store);
+    Filament::bootCurrentPanel();
+
+    livewire(CreateRole::class)
+        ->assertOk();
+});
+
+it('can create a global role from the tenant context without team scoping', function (): void {
+    $role = Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+
+    Permission::firstOrCreate(['name' => 'Create:Role', 'guard_name' => 'web']);
+    Permission::firstOrCreate(['name' => 'ViewAny:Role', 'guard_name' => 'web']);
+
+    $role->givePermissionTo(['Create:Role', 'ViewAny:Role']);
+
+    $user = User::factory()->create();
+    $user->stores()->attach($this->store);
+    $user->assignRole('super_admin');
+
+    $this->actingAs($user);
+    Filament::setTenant($this->store);
+    Filament::bootCurrentPanel();
+
+    livewire(CreateRole::class)
+        ->fillForm([
+            'name' => 'store_operator',
+            'guard_name' => 'web',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(Role::query()->where('name', 'store_operator')->where('guard_name', 'web')->exists())->toBeTrue();
+});
+
+it('allows global super admins to access tenant-protected api routes', function (): void {
+    Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+
+    $superAdmin = User::factory()->create();
+    $superAdmin->assignRole('super_admin');
+
+    Sanctum::actingAs($superAdmin);
+
+    $this->getJson('/api/pos-events', [
+        'X-Tenant' => $this->store->slug,
+    ])->assertSuccessful();
+});
+
+it('forbids users without tenant access on tenant-protected api routes', function (): void {
+    $user = User::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    $this->getJson('/api/pos-events', [
+        'X-Tenant' => $this->store->slug,
+    ])->assertForbidden();
+});
+
+it('allows store-attached users on tenant-protected api routes', function (): void {
+    $user = User::factory()->create();
+    $user->stores()->attach($this->store);
+
+    Sanctum::actingAs($user);
+
+    $this->getJson('/api/pos-events', [
+        'X-Tenant' => $this->store->slug,
+    ])->assertSuccessful();
+});


### PR DESCRIPTION
## Summary
- remove tenant/team-specific fields and uniqueness scoping from the Shield role resource so role creation is consistently global
- add a shared `User::hasGlobalSuperAdminRole()` helper and use it across tenant authorization checks
- allow global super admins through shared API tenant authorization while keeping non-members blocked
- add Pest regression tests for Filament role creation in tenant context and API tenant access behavior

## Test plan
- [x] `php artisan test --compact tests/Feature/Tenancy/GlobalRolesTenantAccessTest.php`
- [x] `vendor/bin/pint --dirty --format agent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tenant authorization and role scoping behavior, which could unintentionally broaden or restrict access if the new global super-admin check is misapplied. Adds regression tests to cover key Filament and API access paths.
> 
> **Overview**
> Makes Filament Shield roles *explicitly global* by removing tenant/team-specific fields and tenant-scoped uniqueness from `RoleResource`, and ensuring role queries aren’t tenant-scoped.
> 
> Introduces `User::hasGlobalSuperAdminRole()` (global, `withoutGlobalScopes()` role check) and switches API tenant authorization and store-access endpoints to use it, so global super admins bypass tenant membership checks while other users remain restricted.
> 
> Adds Pest regression coverage for creating roles from a tenant context and for tenant-protected API route access for super admins vs. non-members.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15e60613d3749dc2e007df282a29134d5350cfd0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->