### PR TITLE
fix: address top Nightwatch production issues

### DIFF
--- a/app/Actions/Webhooks/HandlePaymentMethodWebhook.php
+++ b/app/Actions/Webhooks/HandlePaymentMethodWebhook.php
@@ -10,42 +10,87 @@ class HandlePaymentMethodWebhook
 {
     public function handle(PaymentMethod $paymentMethod, string $eventType, ?string $accountId = null): void
     {
-        if (!$accountId) {
+        if (! $accountId) {
             \Log::warning('Payment method webhook received but no account ID provided', [
                 'payment_method_id' => $paymentMethod->id,
             ]);
+
             return;
         }
-        
+
         $store = Store::where('stripe_account_id', $accountId)->first();
-        
-        if (!$store) {
+
+        if (! $store) {
             \Log::warning('Payment method webhook received but store not found', [
                 'payment_method_id' => $paymentMethod->id,
                 'account_id' => $accountId,
             ]);
+
+            return;
+        }
+
+        $existingPaymentMethod = ConnectedPaymentMethod::query()
+            ->where('stripe_payment_method_id', $paymentMethod->id)
+            ->where('stripe_account_id', $store->stripe_account_id)
+            ->first();
+
+        $resolvedStripeCustomerId = $paymentMethod->customer ?: $existingPaymentMethod?->stripe_customer_id;
+
+        if (! $resolvedStripeCustomerId) {
+            \Log::warning('Skipping payment method webhook because stripe customer id is missing', [
+                'payment_method_id' => $paymentMethod->id,
+                'event_type' => $eventType,
+                'account_id' => $store->stripe_account_id,
+            ]);
+
             return;
         }
 
         $data = [
             'stripe_payment_method_id' => $paymentMethod->id,
             'stripe_account_id' => $store->stripe_account_id,
-            'stripe_customer_id' => $paymentMethod->customer ?? null,
+            'stripe_customer_id' => $resolvedStripeCustomerId,
             'type' => $paymentMethod->type,
             'card_brand' => $paymentMethod->card->brand ?? null,
             'card_last4' => $paymentMethod->card->last4 ?? null,
             'card_exp_month' => $paymentMethod->card->exp_month ?? null,
             'card_exp_year' => $paymentMethod->card->exp_year ?? null,
-            'metadata' => $paymentMethod->metadata ? (array) $paymentMethod->metadata : null,
+            'metadata' => $this->stripeObjectToPlainArray($paymentMethod->metadata),
         ];
 
-        ConnectedPaymentMethod::updateOrCreate(
-            [
-                'stripe_payment_method_id' => $paymentMethod->id,
-                'stripe_account_id' => $store->stripe_account_id,
-            ],
-            $data
-        );
+        if ($existingPaymentMethod) {
+            $existingPaymentMethod->fill($data);
+            $existingPaymentMethod->save();
+
+            return;
+        }
+
+        ConnectedPaymentMethod::query()->create($data);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function stripeObjectToPlainArray(mixed $obj): ?array
+    {
+        if ($obj === null) {
+            return null;
+        }
+
+        if (is_object($obj) && method_exists($obj, 'toArray')) {
+            $arr = $obj->toArray();
+
+            return is_array($arr) ? $arr : null;
+        }
+
+        $encoded = json_encode($obj);
+
+        if ($encoded === false) {
+            return null;
+        }
+
+        $decoded = json_decode($encoded, true);
+
+        return is_array($decoded) ? $decoded : null;
     }
 }
-

--- a/app/Http/Controllers/Api/PurchasesController.php
+++ b/app/Http/Controllers/Api/PurchasesController.php
@@ -20,6 +20,12 @@ class PurchasesController extends BaseApiController
 {
     protected PurchaseService $purchaseService;
 
+    /** @var array<string, array<int, ConnectedProduct>> */
+    protected array $connectedProductsCache = [];
+
+    /** @var array<string, array<int, ProductVariant>> */
+    protected array $productVariantsCache = [];
+
     public function __construct(PurchaseService $purchaseService)
     {
         $this->purchaseService = $purchaseService;
@@ -937,28 +943,25 @@ class PurchasesController extends BaseApiController
         }
 
         // Fetch products and variants in bulk
-        $products = ConnectedProduct::whereIn('id', array_unique($productIds))
-            ->where('stripe_account_id', $stripeAccountId)
-            ->get()
-            ->keyBy('id');
-
-        $variants = ProductVariant::whereIn('id', array_unique($variantIds))
-            ->where('stripe_account_id', $stripeAccountId)
-            ->get()
-            ->keyBy('id');
+        $products = $this->getConnectedProductsForAccount($stripeAccountId, $productIds);
+        $variants = $this->getProductVariantsForAccount($stripeAccountId, $variantIds);
 
         // Enrich each item from current product data
         return array_map(function ($item) use ($products, $variants, $itemRefunds) {
             $productId = isset($item['product_id']) ? (int) $item['product_id'] : null;
             $variantId = isset($item['variant_id']) ? (int) $item['variant_id'] : null;
+            $variant = $variantId ? ($variants[$variantId] ?? null) : null;
+
+            if (! $productId && $variant) {
+                $productId = (int) $variant->connected_product_id;
+            }
 
             $product = $productId ? ($products[$productId] ?? null) : null;
-            $variant = $variantId ? ($variants[$variantId] ?? null) : null;
 
             // Get product name (from variant if available, otherwise product)
             $productName = null;
-            if ($variant && $variant->product) {
-                $productName = $variant->product->name;
+            if ($variant && $product) {
+                $productName = $product->name;
                 if ($variant->variant_name !== 'Default') {
                     $productName .= ' - '.$variant->variant_name;
                 }
@@ -997,10 +1000,7 @@ class PurchasesController extends BaseApiController
             // Get article group code and product code
             $articleGroupCode = null;
             $productCode = null;
-            if ($variant && $variant->product) {
-                $articleGroupCode = $variant->product->article_group_code;
-                $productCode = $variant->product->product_code;
-            } elseif ($product) {
+            if ($product) {
                 $articleGroupCode = $product->article_group_code;
                 $productCode = $product->product_code;
             }
@@ -1035,6 +1035,80 @@ class PurchasesController extends BaseApiController
                     : null,
             ];
         }, $items);
+    }
+
+    /**
+     * @param  array<int, int>  $productIds
+     * @return array<int, ConnectedProduct>
+     */
+    protected function getConnectedProductsForAccount(string $stripeAccountId, array $productIds): array
+    {
+        $uniqueProductIds = array_values(array_unique(array_filter($productIds)));
+        if ($uniqueProductIds === []) {
+            return [];
+        }
+
+        if (! isset($this->connectedProductsCache[$stripeAccountId])) {
+            $this->connectedProductsCache[$stripeAccountId] = [];
+        }
+
+        $missingProductIds = array_values(array_diff(
+            $uniqueProductIds,
+            array_keys($this->connectedProductsCache[$stripeAccountId])
+        ));
+
+        if ($missingProductIds !== []) {
+            $fetchedProducts = ConnectedProduct::query()
+                ->where('stripe_account_id', $stripeAccountId)
+                ->whereIn('id', $missingProductIds)
+                ->get()
+                ->keyBy('id')
+                ->all();
+
+            $this->connectedProductsCache[$stripeAccountId] += $fetchedProducts;
+        }
+
+        return array_intersect_key(
+            $this->connectedProductsCache[$stripeAccountId],
+            array_flip($uniqueProductIds)
+        );
+    }
+
+    /**
+     * @param  array<int, int>  $variantIds
+     * @return array<int, ProductVariant>
+     */
+    protected function getProductVariantsForAccount(string $stripeAccountId, array $variantIds): array
+    {
+        $uniqueVariantIds = array_values(array_unique(array_filter($variantIds)));
+        if ($uniqueVariantIds === []) {
+            return [];
+        }
+
+        if (! isset($this->productVariantsCache[$stripeAccountId])) {
+            $this->productVariantsCache[$stripeAccountId] = [];
+        }
+
+        $missingVariantIds = array_values(array_diff(
+            $uniqueVariantIds,
+            array_keys($this->productVariantsCache[$stripeAccountId])
+        ));
+
+        if ($missingVariantIds !== []) {
+            $fetchedVariants = ProductVariant::query()
+                ->where('stripe_account_id', $stripeAccountId)
+                ->whereIn('id', $missingVariantIds)
+                ->get()
+                ->keyBy('id')
+                ->all();
+
+            $this->productVariantsCache[$stripeAccountId] += $fetchedVariants;
+        }
+
+        return array_intersect_key(
+            $this->productVariantsCache[$stripeAccountId],
+            array_flip($uniqueVariantIds)
+        );
     }
 
     /**

--- a/app/Http/Controllers/Webhooks/StripeConnectWebhookController.php
+++ b/app/Http/Controllers/Webhooks/StripeConnectWebhookController.php
@@ -46,12 +46,12 @@ class StripeConnectWebhookController extends Controller
         if (empty($payload)) {
             $payload = file_get_contents('php://input');
         }
-        
+
         // Get signature header - check multiple sources
         // Laravel normalizes headers, but Stripe sends "Stripe-Signature"
         // Try to get raw headers first (before Laravel processing)
         $signature = null;
-        
+
         // Method 1: Try PHP's native getallheaders() function (if available)
         if (function_exists('getallheaders')) {
             $rawHeaders = getallheaders();
@@ -64,7 +64,7 @@ class StripeConnectWebhookController extends Controller
                 }
             }
         }
-        
+
         // Method 2: Try apache_request_headers() (Apache-specific)
         if (empty($signature) && function_exists('apache_request_headers')) {
             $apacheHeaders = apache_request_headers();
@@ -77,18 +77,18 @@ class StripeConnectWebhookController extends Controller
                 }
             }
         }
-        
+
         // Method 3: Check Laravel's header bag
         if (empty($signature)) {
             $signature = $request->header('Stripe-Signature');
         }
-        
+
         // Method 4: Check $_SERVER directly (Laravel converts headers to HTTP_* format)
         if (empty($signature)) {
             // Check HTTP_STRIPE_SIGNATURE (Laravel converts "Stripe-Signature" to "HTTP_STRIPE_SIGNATURE")
             $signature = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? null;
         }
-        
+
         // Method 5: Check all Laravel headers case-insensitively
         if (empty($signature)) {
             $allHeaders = $request->headers->all();
@@ -99,7 +99,7 @@ class StripeConnectWebhookController extends Controller
                 }
             }
         }
-        
+
         // Method 6: Last resort - check $_SERVER for any variation
         if (empty($signature)) {
             foreach ($_SERVER as $key => $value) {
@@ -109,19 +109,19 @@ class StripeConnectWebhookController extends Controller
                 }
             }
         }
-        
+
         // Trim whitespace from signature if found
-        if (!empty($signature)) {
+        if (! empty($signature)) {
             $signature = trim($signature);
         }
-        
+
         // Check if signature is empty or just whitespace
         // empty() will catch null, false, 0, '', '0', [], etc.
         // But we also want to catch strings that are only whitespace
-        $signatureIsValid = !empty($signature) && strlen(trim($signature ?? '')) > 0;
+        $signatureIsValid = ! empty($signature) && strlen(trim($signature ?? '')) > 0;
 
         // Validate signature header is present and not empty
-        if (!$signatureIsValid) {
+        if (! $signatureIsValid) {
             // Collect all HTTP headers from $_SERVER for debugging
             $httpHeaders = [];
             foreach ($_SERVER as $key => $value) {
@@ -129,7 +129,7 @@ class StripeConnectWebhookController extends Controller
                     $httpHeaders[$key] = $value;
                 }
             }
-            
+
             // Get all HTTP_* keys for debugging
             $httpKeys = [];
             foreach (array_keys($_SERVER) as $key) {
@@ -137,7 +137,7 @@ class StripeConnectWebhookController extends Controller
                     $httpKeys[] = $key;
                 }
             }
-            
+
             // Log comprehensive debugging information
             \Log::error('Stripe webhook signature header missing', [
                 'method' => $request->method(),
@@ -146,11 +146,12 @@ class StripeConnectWebhookController extends Controller
                 'user_agent' => $request->userAgent(),
                 'laravel_headers' => $request->headers->all(),
                 'server_headers' => $httpHeaders,
-                'has_content' => !empty($payload),
+                'has_content' => ! empty($payload),
                 'content_length' => strlen($payload ?? ''),
                 'content_type' => $request->header('Content-Type'),
                 'all_http_keys' => $httpKeys,
             ]);
+
             // Return 400 (Bad Request) - this indicates the request is malformed
             // Note: If you're seeing 403 (Forbidden) in Stripe's dashboard, it might be:
             // 1. A proxy/load balancer (like Herd's Nginx) stripping the header
@@ -175,6 +176,7 @@ class StripeConnectWebhookController extends Controller
             // Misconfiguration – don't throw to Stripe, just log.
             \Log::error('Stripe webhook secret not configured');
             report(new \RuntimeException('Stripe webhook secret not configured.'));
+
             return response()->json([
                 'message' => 'Webhook misconfigured',
             ], 500);
@@ -185,6 +187,7 @@ class StripeConnectWebhookController extends Controller
             \Log::error('Stripe webhook payload is empty', [
                 'signature' => $signature ? 'present' : 'missing',
             ]);
+
             return response()->json([
                 'message' => 'Invalid payload',
             ], 400);
@@ -201,32 +204,33 @@ class StripeConnectWebhookController extends Controller
             \Log::error('Stripe webhook invalid payload', [
                 'error' => $e->getMessage(),
                 'payload_length' => strlen($payload),
-                'signature_present' => !empty($signature),
+                'signature_present' => ! empty($signature),
             ]);
+
             return response()->json([
                 'message' => 'Invalid payload',
             ], 400);
         } catch (SignatureVerificationException $e) {
             // Invalid signature - log with signature format info (truncated for security)
-            $signaturePreview = $signature ? (substr($signature, 0, 50) . '...') : 'missing';
+            $signaturePreview = $signature ? (substr($signature, 0, 50).'...') : 'missing';
             $signatureParts = $signature ? explode(',', $signature) : [];
-            
+
             // Check if the error is about missing signatures (this should have been caught earlier)
             $isMissingSignatureError = stripos($e->getMessage(), 'No signatures found') !== false;
-            
+
             \Log::error('Stripe webhook signature verification failed', [
                 'error' => $e->getMessage(),
                 'error_class' => get_class($e),
                 'is_missing_signature_error' => $isMissingSignatureError,
-                'signature_present' => !empty($signature),
+                'signature_present' => ! empty($signature),
                 'signature_length' => strlen($signature ?? ''),
                 'signature_preview' => $signaturePreview,
                 'signature_parts_count' => count($signatureParts),
                 'payload_length' => strlen($payload),
-                'secret_configured' => !empty($secret),
+                'secret_configured' => ! empty($secret),
                 'secret_length' => strlen($secret ?? ''),
             ]);
-            
+
             // Return the exact error message from Stripe
             // Note: If you see 403 in Stripe dashboard but we return 400, check:
             // 1. Proxy/load balancer converting status codes
@@ -250,7 +254,7 @@ class StripeConnectWebhookController extends Controller
         ]);
 
         // Warn if account ID is missing for Connect webhooks (except account events)
-        if (!$accountId && !in_array($event->type, ['account.created', 'account.updated', 'account.deleted'])) {
+        if (! $accountId && ! in_array($event->type, ['account.created', 'account.updated', 'account.deleted'])) {
             \Log::warning('Stripe webhook event missing account ID - may not be a Connect webhook', [
                 'event_type' => $event->type,
                 'event_id' => $event->id,
@@ -292,12 +296,12 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Account {$account->id} deletion processed";
                     break;
 
-                // Customer events
+                    // Customer events
                 case 'customer.created':
                 case 'customer.updated':
                     /** @var Customer $customer */
                     $customer = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event';
                     }
                     $customerHandler->handle($customer, $event->type, $accountId);
@@ -311,7 +315,7 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = 'Customer deletion event received (not implemented)';
                     break;
 
-                // Subscription events
+                    // Subscription events
                 case 'customer.subscription.created':
                 case 'customer.subscription.updated':
                 case 'customer.subscription.deleted':
@@ -320,7 +324,7 @@ class StripeConnectWebhookController extends Controller
                 case 'customer.subscription.trial_will_end':
                     /** @var Subscription $subscription */
                     $subscription = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event';
                     }
                     $subscriptionHandler->handle($subscription, $event->type, $accountId);
@@ -328,13 +332,13 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Subscription {$subscription->id} ({$event->type}) processed";
                     break;
 
-                // Product events
+                    // Product events
                 case 'product.created':
                 case 'product.updated':
                 case 'product.deleted':
                     /** @var Product $product */
                     $product = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event';
                     }
                     $productHandler->handle($product, $event->type, $accountId);
@@ -342,13 +346,13 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Product {$product->id} ({$event->type}) processed";
                     break;
 
-                // Price events
+                    // Price events
                 case 'price.created':
                 case 'price.updated':
                 case 'price.deleted':
                     /** @var Price $price */
                     $price = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event';
                     }
                     $priceHandler->handle($price, $event->type, $accountId);
@@ -356,7 +360,7 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Price {$price->id} ({$event->type}) processed";
                     break;
 
-                // Charge events
+                    // Charge events
                 case 'charge.created':
                 case 'charge.updated':
                 case 'charge.succeeded':
@@ -365,9 +369,14 @@ class StripeConnectWebhookController extends Controller
                 case 'charge.captured':
                 case 'charge.refunded':
                 case 'charge.refund.updated':
-                    /** @var Charge $charge */
-                    $charge = $event->data->object;
-                    if (!$accountId) {
+                    $chargeObject = $event->data->object;
+                    if (! $chargeObject instanceof Charge) {
+                        $result['warnings'][] = "Unexpected webhook object for {$event->type}: ".get_debug_type($chargeObject);
+                        $result['message'] = "Skipped {$event->type} because payload object was not a charge";
+                        break;
+                    }
+                    $charge = $chargeObject;
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event, attempting to extract from charge object';
                     }
                     $chargeHandler->handle($charge, $event->type, $accountId);
@@ -375,14 +384,14 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Charge {$charge->id} ({$event->type}) processed";
                     break;
 
-                // Payment method events
+                    // Payment method events
                 case 'payment_method.attached':
                 case 'payment_method.detached':
                 case 'payment_method.updated':
                 case 'payment_method.automatically_updated':
                     /** @var PaymentMethod $paymentMethod */
                     $paymentMethod = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event';
                     }
                     $paymentMethodHandler->handle($paymentMethod, $event->type, $accountId);
@@ -390,12 +399,12 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Payment method {$paymentMethod->id} ({$event->type}) processed";
                     break;
 
-                // Payment link events
+                    // Payment link events
                 case 'payment_link.created':
                 case 'payment_link.updated':
                     /** @var PaymentLink $paymentLink */
                     $paymentLink = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event';
                     }
                     $paymentLinkHandler->handle($paymentLink, $event->type, $accountId);
@@ -403,13 +412,13 @@ class StripeConnectWebhookController extends Controller
                     $result['message'] = "Payment link {$paymentLink->id} ({$event->type}) processed";
                     break;
 
-                // Transfer events
+                    // Transfer events
                 case 'transfer.created':
                 case 'transfer.updated':
                 case 'transfer.reversed':
                     /** @var Transfer $transfer */
                     $transfer = $event->data->object;
-                    if (!$accountId) {
+                    if (! $accountId) {
                         $result['warnings'][] = 'No account ID found in event, attempting to extract from transfer object';
                     }
                     $transferHandler->handle($transfer, $event->type, $accountId);
@@ -440,14 +449,14 @@ class StripeConnectWebhookController extends Controller
         }
 
         // Add warning if account ID was missing
-        if (!$accountId && !in_array($event->type, ['account.created', 'account.updated', 'account.deleted'])) {
+        if (! $accountId && ! in_array($event->type, ['account.created', 'account.updated', 'account.deleted'])) {
             $result['warnings'][] = 'No account ID found in event - this may indicate the webhook is from the platform account instead of a connected account';
         }
 
         // Ensure we have a message if none was set
         if (empty($result['message'])) {
-            $result['message'] = $result['processed'] 
-                ? "Event {$event->type} processed successfully" 
+            $result['message'] = $result['processed']
+                ? "Event {$event->type} processed successfully"
                 : "Event {$event->type} received but not processed";
         }
 
@@ -460,7 +469,7 @@ class StripeConnectWebhookController extends Controller
         // Save webhook log to database
         try {
             // Check if table exists before trying to save
-            if (!\Illuminate\Support\Facades\Schema::hasTable('webhook_logs')) {
+            if (! \Illuminate\Support\Facades\Schema::hasTable('webhook_logs')) {
                 \Log::warning('webhook_logs table does not exist - run migration first', [
                     'event_id' => $event->id,
                 ]);
@@ -473,8 +482,8 @@ class StripeConnectWebhookController extends Controller
                     'account_id' => $accountId,
                     'processed' => $result['processed'],
                     'message' => $result['message'],
-                    'warnings' => !empty($result['warnings']) ? $result['warnings'] : null,
-                    'errors' => !empty($result['errors']) ? $result['errors'] : null,
+                    'warnings' => ! empty($result['warnings']) ? $result['warnings'] : null,
+                    'errors' => ! empty($result['errors']) ? $result['errors'] : null,
                     'request_data' => [
                         'event_type' => $event->type,
                         'event_id' => $event->id,
@@ -484,7 +493,7 @@ class StripeConnectWebhookController extends Controller
                     ],
                     'response_data' => $result,
                     'http_status_code' => 200,
-                    'error_message' => !empty($result['errors']) ? implode('; ', $result['errors']) : null,
+                    'error_message' => ! empty($result['errors']) ? implode('; ', $result['errors']) : null,
                 ]);
 
                 // Cleanup old records (keep max 100 per store)

--- a/app/Http/Middleware/GuardLivewireUpdatePayload.php
+++ b/app/Http/Middleware/GuardLivewireUpdatePayload.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GuardLivewireUpdatePayload
+{
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->is('livewire/update') && $request->isMethod('post') && $request->isJson()) {
+            $payload = $request->json()->all();
+            $components = $payload['components'] ?? null;
+
+            if (! is_array($components)) {
+                return response()->json([
+                    'message' => 'Malformed Livewire update payload.',
+                ], 400);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,6 +15,9 @@ return Application::configure(basePath: dirname(__DIR__))
         // Trust proxies for Herd's reverse proxy setup
         $middleware->trustProxies(at: '*');
 
+        // Reject malformed Livewire update payloads before Livewire hydration.
+        $middleware->append(\App\Http\Middleware\GuardLivewireUpdatePayload::class);
+
         // Set dynamic APP_URL based on request (must be before CORS)
         $middleware->append(\App\Http\Middleware\SetDynamicAppUrl::class);
 

--- a/tests/Feature/LivewireUpdateGuardTest.php
+++ b/tests/Feature/LivewireUpdateGuardTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('malformed livewire update payload is rejected early', function () {
+    $this->withoutMiddleware(VerifyCsrfToken::class);
+
+    $response = $this->postJson('/livewire/update', [
+        '_nightwatch_error' => 'NOT_ENABLED',
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJsonPath('message', 'Malformed Livewire update payload.');
+});

--- a/tests/Feature/PurchasesApiTest.php
+++ b/tests/Feature/PurchasesApiTest.php
@@ -8,6 +8,7 @@ use App\Models\PosSession;
 use App\Models\Store;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Laravel\Sanctum\Sanctum;
 
 uses(RefreshDatabase::class);
@@ -347,4 +348,58 @@ test('kiosk sales report supports cursor and updated_since filters', function ()
     $response->assertJsonPath('data.0.net_amount_ore', 15000);
     $response->assertJsonPath('data.0.is_refund', true);
     $response->assertJsonPath('meta.cursor', $olderKioskCharge->id);
+});
+
+test('purchases index avoids repeated product lookup queries for metadata fallback enrichment', function () {
+    $user = User::factory()->create();
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_test_purchase_lookup_cache']);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    $posDevice = PosDevice::factory()->create(['store_id' => $store->id]);
+    $session = PosSession::factory()->create([
+        'store_id' => $store->id,
+        'pos_device_id' => $posDevice->id,
+        'user_id' => $user->id,
+        'status' => 'open',
+    ]);
+
+    $product = ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'name' => 'Lookup cache product',
+    ]);
+
+    foreach (range(1, 3) as $index) {
+        ConnectedCharge::factory()->create([
+            'stripe_account_id' => $store->stripe_account_id,
+            'pos_session_id' => $session->id,
+            'paid' => true,
+            'status' => 'succeeded',
+            'amount' => 1000 * $index,
+            'metadata' => [
+                'items' => [
+                    [
+                        'id' => 'item_'.$index,
+                        'product_id' => $product->id,
+                        'quantity' => 1,
+                        'unit_price' => 1000,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    Sanctum::actingAs($user, ['*']);
+
+    $connectedProductQueries = 0;
+    DB::listen(function ($query) use (&$connectedProductQueries) {
+        if (str_contains($query->sql, 'from "connected_products"')) {
+            $connectedProductQueries++;
+        }
+    });
+
+    $response = $this->getJson('/api/purchases?per_page=20&page=0');
+
+    $response->assertOk();
+    expect($connectedProductQueries)->toBe(1);
 });

--- a/tests/Feature/WebhookAndObserverPosSessionTest.php
+++ b/tests/Feature/WebhookAndObserverPosSessionTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Actions\Webhooks\HandleChargeWebhook;
+use App\Actions\Webhooks\HandlePaymentMethodWebhook;
 use App\Models\ConnectedCharge;
+use App\Models\ConnectedPaymentMethod;
 use App\Models\PosEvent;
 use App\Models\PosSession;
 use App\Models\Store;
@@ -113,4 +115,78 @@ it('creates POS events when ConnectedCharge has pos_session_id', function () {
     ]);
 
     expect(PosEvent::where('event_code', PosEvent::EVENT_SALES_RECEIPT)->count())->toBe(1);
+});
+
+it('ignores charge refund update events when webhook object is not a charge', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+
+    $secret = 'whsec_test_refund_event';
+    config()->set('cashierconnect.webhook.secret', $secret);
+
+    $payload = json_encode([
+        'id' => 'evt_'.uniqid(),
+        'object' => 'event',
+        'type' => 'charge.refund.updated',
+        'account' => $store->stripe_account_id,
+        'data' => [
+            'object' => [
+                'id' => 're_'.uniqid(),
+                'object' => 'refund',
+                'charge' => 'ch_'.uniqid(),
+            ],
+        ],
+    ], JSON_THROW_ON_ERROR);
+
+    $timestamp = time();
+    $signedPayload = "{$timestamp}.{$payload}";
+    $signature = hash_hmac('sha256', $signedPayload, $secret);
+    $signatureHeader = "t={$timestamp},v1={$signature}";
+
+    $response = $this->withHeader('Stripe-Signature', $signatureHeader)
+        ->postJson('/api/connectWebhook', json_decode($payload, true, 512, JSON_THROW_ON_ERROR));
+
+    $response->assertOk()
+        ->assertJsonPath('event_type', 'charge.refund.updated')
+        ->assertJsonPath('processed', false)
+        ->assertJsonPath('errors', []);
+});
+
+it('does not overwrite existing payment method customer with null value', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+
+    $existing = ConnectedPaymentMethod::query()->create([
+        'stripe_payment_method_id' => 'pm_'.uniqid(),
+        'stripe_account_id' => $store->stripe_account_id,
+        'stripe_customer_id' => 'cus_existing_123',
+        'type' => 'card',
+        'card_brand' => 'visa',
+        'card_last4' => '4242',
+        'card_exp_month' => 1,
+        'card_exp_year' => 2030,
+    ]);
+
+    $paymentMethod = \Stripe\PaymentMethod::constructFrom([
+        'id' => $existing->stripe_payment_method_id,
+        'customer' => null,
+        'type' => 'card',
+        'card' => [
+            'brand' => 'mastercard',
+            'last4' => '4444',
+            'exp_month' => 12,
+            'exp_year' => 2032,
+        ],
+        'metadata' => [],
+    ]);
+
+    app(HandlePaymentMethodWebhook::class)->handle(
+        $paymentMethod,
+        'payment_method.updated',
+        $store->stripe_account_id
+    );
+
+    $existing->refresh();
+
+    expect($existing->stripe_customer_id)->toBe('cus_existing_123')
+        ->and($existing->card_brand)->toBe('mastercard')
+        ->and($existing->card_last4)->toBe('4444');
 });


### PR DESCRIPTION
## Summary
- Harden Stripe webhook processing by guarding charge event object types and avoiding error reports for `charge.refund.updated` payloads that are not `Stripe\Charge` objects.
- Prevent `connected_payment_methods.stripe_customer_id` null-write violations by preserving existing customer IDs and skipping updates that cannot satisfy schema requirements.
- Reduce `/api/purchases` lookup overhead by adding request-scoped caches for product and variant enrichment and removing repeated fallback queries.
- Reject malformed `/livewire/update` JSON payloads before Livewire hydration to stop noisy production exceptions from invalid scripted traffic.
- Add regression tests for webhook object mismatch handling, payment-method null customer behavior, malformed Livewire updates, and purchase enrichment query reuse.

## Test plan
- [x] `php artisan test --compact tests/Feature/WebhookAndObserverPosSessionTest.php tests/Feature/PurchasesApiTest.php tests/Feature/LivewireUpdateGuardTest.php`
- [x] `vendor/bin/pint --dirty --format agent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Stripe webhook ingestion and payment method persistence behavior, which can affect production event processing and data integrity. Also adds a global middleware that may reject some Livewire traffic if the payload shape differs unexpectedly.
> 
> **Overview**
> **Hardens Stripe Connect webhook processing** by skipping `charge.*` events when the payload object isn’t a `Stripe\Charge`, avoiding exceptions on events like `charge.refund.updated` that sometimes deliver `refund` objects.
> 
> **Prevents invalid writes from payment method webhooks** by resolving/preserving `stripe_customer_id` (falling back to an existing DB value) and skipping updates when no customer id can be determined; also normalizes Stripe `metadata` into a plain array before persistence.
> 
> **Reduces `/api/purchases` enrichment query overhead** by introducing request-scoped caches for `ConnectedProduct`/`ProductVariant` lookups and slightly adjusting fallback enrichment logic to derive product id from variants.
> 
> **Adds a global guard for malformed Livewire update requests** (`POST /livewire/update` JSON must include an array `components`) to fail fast with 400, with regression tests covering webhook skipping, payment-method customer preservation, query caching, and Livewire payload rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9ec1c70ff8932033fb9c5e9b9fe44226693afa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->