### PR TITLE
fix: guard non-JSON Livewire update payloads (Nightwatch probes)

### DIFF
--- a/app/Http/Middleware/GuardLivewireUpdatePayload.php
+++ b/app/Http/Middleware/GuardLivewireUpdatePayload.php
@@ -13,8 +13,10 @@ class GuardLivewireUpdatePayload
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->is('livewire/update') && $request->isMethod('post') && $request->isJson()) {
-            $payload = $request->json()->all();
+        if ($request->is('livewire/update') && $request->isMethod('post')) {
+            $payload = $request->isJson()
+                ? $request->json()->all()
+                : $request->all();
             $components = $payload['components'] ?? null;
 
             if (! is_array($components)) {

--- a/tests/Feature/LivewireUpdateGuardTest.php
+++ b/tests/Feature/LivewireUpdateGuardTest.php
@@ -15,3 +15,17 @@ test('malformed livewire update payload is rejected early', function () {
     $response->assertStatus(400)
         ->assertJsonPath('message', 'Malformed Livewire update payload.');
 });
+
+test('malformed livewire update payload as form data is rejected early', function () {
+    $this->withoutMiddleware(VerifyCsrfToken::class);
+
+    $response = $this->call('POST', '/livewire/update', [
+        '_nightwatch_error' => 'NOT_ENABLED',
+    ], [], [], [
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        'HTTP_ACCEPT' => 'text/html,application/json',
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJsonPath('message', 'Malformed Livewire update payload.');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the exception pattern described for Nightwatch issue `bridge-agent-test-1778923618` in GitHub issue #74.

`GuardLivewireUpdatePayload` only ran when `Request::isJson()` was true. Clients that `POST /livewire/update` with `application/x-www-form-urlencoded` bodies (for example including `_nightwatch_error`) could skip the guard and hit Livewire, which may throw while handling a malformed payload.

## Changes

- Validate that `components` is an array for **all** POST requests to `livewire/update`, using the JSON body when the request is JSON and falling back to `$request->all()` otherwise.
- Add a feature test for the form-encoded malformed payload case.

**Refs:** #74
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de31952c-a81e-4fed-b7c4-ead2ee8325e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de31952c-a81e-4fed-b7c4-ead2ee8325e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

