### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,3 +398,41 @@ that an implementing agent can write code without making decisions.
 `/vendor/filament/blueprint/resources/markdown/planning/overview.md` for plan format,
 required sections, and what to clarify with the user before planning.
 </laravel-boost-guidelines>
+
+## Cursor Cloud specific instructions
+
+### System Dependencies
+
+The VM requires PHP 8.4, Composer, and PostgreSQL 16. These are installed by the update script via `apt`. Redis is only needed if running Horizon (not required for basic dev/testing).
+
+### Database Setup
+
+- The dev `.env` uses **PostgreSQL** (`pos_stripe`) instead of the `.env.example` default of SQLite. SQLite has migration issues with the workflow tenancy index migration (the `indexExists()` helper doesn't support SQLite).
+- Tests use a separate PostgreSQL database `pos_stripe_test` (configured in `phpunit.xml`). The update script creates both databases idempotently.
+- **NEVER run `migrate:fresh` or `migrate:refresh`** on the dev database. Use `php artisan test` for test migrations. See AGENTS.md `laravel/core` rules.
+
+### Private Composer Packages (Auth Required)
+
+Two packages require private repo auth and are **not installed** in the default Cloud Agent environment:
+- `leek/filament-workflows` (from `filament-workflow-engine.composer.sh`) — requires license key in `auth.json`
+- `filament/blueprint` (from `packages.filamentphp.com`) — dev-only, requires Filament license
+
+The app boots fine without these. The workflow plugin is loaded conditionally via `class_exists()` in `AppPanelProvider`. If the user provides credentials, add them to `/workspace/auth.json` (gitignored) per `docs/WORKFLOW_ENGINE_SETUP.md`.
+
+### Running the App
+
+- `php artisan serve --host=0.0.0.0 --port=8000` for the web server
+- `npm run dev` for Vite hot-reload (or `npm run build` for static assets)
+- `composer run dev` runs all dev services concurrently (server, queue, logs, vite) via `npx concurrently`
+- The Filament panel is at `/app/login`. Multi-tenancy requires a Store record; use `php artisan make:filament-user` and assign `super_admin` role.
+
+### Running Tests
+
+- `php artisan test --compact` runs the full Pest test suite
+- `VariantStripeProductTest` has a pre-existing hang bug: the `test_creating_variant_creates_stripe_product` test leaks state that causes `test_variant_product_name_includes_options` to hang indefinitely. Skip or run individually.
+- PostgreSQL must be running: `sudo pg_ctlcluster 16 main start`
+
+### Lint
+
+- `vendor/bin/pint --dirty --format agent` for formatting (per AGENTS.md pint rules)
+- `vendor/bin/pint --test --format agent` to check without modifying

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,11 +413,11 @@ The VM requires PHP 8.4, Composer, and PostgreSQL 16. These are installed by the
 
 ### Private Composer Packages (Auth Required)
 
-Two packages require private repo auth and are **not installed** in the default Cloud Agent environment:
-- `leek/filament-workflows` (from `filament-workflow-engine.composer.sh`) — requires license key in `auth.json`
-- `filament/blueprint` (from `packages.filamentphp.com`) — dev-only, requires Filament license
+Two packages require private repo auth via `/workspace/auth.json` (gitignored):
+- `leek/filament-workflows` (from `filament-workflow-engine.composer.sh`) — installed via `FILAMENT_WORKFLOW_ENGINE_LICENSE_KEY` secret and the licensee email (stored in `FILAMENT_WORKFLOW_ENGINE_LICENSE_EMAIL` secret)
+- `filament/blueprint` (from `packages.filamentphp.com`) — dev-only, requires a separate Filament license; **not installed** (app and tests work without it)
 
-The app boots fine without these. The workflow plugin is loaded conditionally via `class_exists()` in `AppPanelProvider`. If the user provides credentials, add them to `/workspace/auth.json` (gitignored) per `docs/WORKFLOW_ENGINE_SETUP.md`.
+The workflow plugin is loaded conditionally via `class_exists()` in `AppPanelProvider`, so the app boots even if the package is missing. The update script auto-generates `auth.json` from the `FILAMENT_WORKFLOW_ENGINE_LICENSE_KEY` env var. See `docs/WORKFLOW_ENGINE_SETUP.md` for manual setup.
 
 ### Running the App
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment setup guidance for Cloud Agents.

### What's included

- **System dependencies**: PHP 8.4, Composer, PostgreSQL 16
- **Database setup**: PostgreSQL for dev (`pos_stripe`) and tests (`pos_stripe_test`), with notes on why SQLite is not used
- **Private Composer packages**: `leek/filament-workflows` installed via `FILAMENT_WORKFLOW_ENGINE_LICENSE_KEY` secret; `filament/blueprint` requires separate Filament license (not installed, non-blocking)
- **Running the app**: Dev server, Vite, and `composer run dev` commands
- **Running tests**: Pest test suite commands and a known `VariantStripeProductTest` hang bug
- **Lint**: Pint formatting commands

### Environment Demo

[filament_admin_panel_demo.mp4](https://cursor.com/agents/bc-07e09aab-8a0f-4ba6-8121-6ebc6ed692cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilament_admin_panel_demo.mp4)

Filament admin panel running locally with multi-tenant store setup.

[Filament dashboard](https://cursor.com/agents/bc-07e09aab-8a0f-4ba6-8121-6ebc6ed692cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilament_dashboard.webp)
[Users management page](https://cursor.com/agents/bc-07e09aab-8a0f-4ba6-8121-6ebc6ed692cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilament_users_page.webp)

### Test Results

Tests: 364 passed, 14 pre-existing failures, 1710 assertions in ~29s (with workflow engine installed).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07e09aab-8a0f-4ba6-8121-6ebc6ed692cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07e09aab-8a0f-4ba6-8121-6ebc6ed692cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

