### PR TITLE
Fix Horizon Filament redirect mount TypeError (Nightwatch nw-ref-47)

### DIFF
--- a/app/Filament/Pages/HorizonRedirectPage.php
+++ b/app/Filament/Pages/HorizonRedirectPage.php
@@ -8,7 +8,6 @@ use BackedEnum;
 use Filament\Facades\Filament;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
-use Illuminate\Http\RedirectResponse;
 
 class HorizonRedirectPage extends Page
 {
@@ -39,8 +38,8 @@ class HorizonRedirectPage extends Page
         return __('filament.navigation.horizon');
     }
 
-    public function mount(): RedirectResponse
+    public function mount(): void
     {
-        return new RedirectResponse(url('/horizon'));
+        $this->redirect(url('/horizon'));
     }
 }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Feature/Filament/HorizonRedirectPageTest.php
+++ b/tests/Feature/Filament/HorizonRedirectPageTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AddonType;
+use App\Filament\Pages\HorizonRedirectPage;
+use App\Models\Addon;
+use App\Models\Store;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+
+use function Pest\Livewire\livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $role = Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web']);
+
+    $this->user = User::factory()->create();
+    $this->store = Store::factory()->create([
+        'stripe_account_id' => 'acct_test_'.fake()->uuid(),
+    ]);
+    $this->user->stores()->attach($this->store);
+    $this->user->assignRole($role);
+
+    Addon::factory()->create([
+        'store_id' => $this->store->id,
+        'type' => AddonType::Pos,
+        'is_active' => true,
+    ]);
+
+    $this->actingAs($this->user);
+    Filament::setTenant($this->store);
+    Filament::bootCurrentPanel();
+});
+
+it('redirects super admins to the Horizon dashboard path on mount', function (): void {
+    livewire(HorizonRedirectPage::class)->assertRedirect(url('/horizon'));
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves the production `TypeError` from Nightwatch (**nw-ref-47**, GitHub **#77**): `HorizonRedirectPage::mount()` was declared to return `RedirectResponse`, but during Livewire requests the container `redirect` binding is Livewire’s `Redirector`, whose `to()` / fluent chain returns **`Redirector`**, not `RedirectResponse`.

## Changes

- **`HorizonRedirectPage`**: `mount(): void` and `$this->redirect(url('/horizon'))` so redirects go through Livewire’s redirect store (correct for full-page and subsequent requests).
- **Tests**: `tests/Feature/Filament/HorizonRedirectPageTest.php` asserts super admins are redirected to `/horizon` on mount.
- **`filament-webflow`**: Updated `Page::getUrl()` overrides to match Filament v4’s parent signature (`$shouldGuessMissingParameters`, `$configuration`). Without this, PHP fatals at bootstrap when loading those page classes against the current Filament version—blocking Artisan and tests locally and in CI.

Refs: #77
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d56a4938-f566-4876-ac98-97395d824208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d56a4938-f566-4876-ac98-97395d824208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

