### PR TITLE
Fix PostgreSQL bigint error when API sends string "null" in JSON bodies

### DIFF
--- a/app/Http/Middleware/CleanApiQueryParameters.php
+++ b/app/Http/Middleware/CleanApiQueryParameters.php
@@ -10,61 +10,82 @@ class CleanApiQueryParameters
 {
     /**
      * Handle an incoming request.
-     * 
-     * Removes null, empty string, and whitespace-only query parameters from API requests.
-     * This ensures that empty search/filter parameters from FlutterFlow are ignored.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * Removes null, empty string, whitespace-only values, and the literal string "null"
+     * from API query strings and JSON/form bodies (FlutterFlow sometimes sends `"null"` for absent IDs).
+     * Passing that string into bigint columns triggers PostgreSQL errors (invalid input syntax for bigint).
+     *
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        // Only apply to API routes
-        if ($request->is('api/*')) {
-            // Skip cleaning for signed URL routes (signature validation requires exact query params)
-            // Also skip for saf-t download route which uses signed URLs
-            if ($request->has('signature') || 
-                $request->has('expires') || 
-                $request->is('api/saf-t/download/*')) {
-                return $next($request);
-            }
-            
-            $query = $request->query->all();
-            
-            // Filter out null, empty strings, whitespace-only strings, and string "null"
-            $cleanedQuery = array_filter($query, function ($value) {
-                // Handle arrays (e.g., filters[])
-                if (is_array($value)) {
-                    // Filter empty values from arrays
-                    $filtered = array_filter($value, function ($item) {
-                        if ($item === null || $item === '' || (is_string($item) && (trim($item) === '' || strtolower(trim($item)) === 'null'))) {
-                            return false;
-                        }
-                        return true;
-                    });
-                    // Only include array if it has at least one non-empty value
-                    return !empty($filtered);
-                }
-                
-                // Handle scalar values (strings, numbers, etc.)
-                if ($value === null || $value === '') {
-                    return false;
-                }
-                
-                // Remove whitespace-only strings and string "null"
-                if (is_string($value)) {
-                    $trimmed = trim($value);
-                    if ($trimmed === '' || strtolower($trimmed) === 'null') {
-                        return false;
-                    }
-                }
-                
-                return true;
-            });
-            
-            // Replace the query parameters with cleaned version
-            $request->query->replace($cleanedQuery);
+        if (! $request->is('api/*')) {
+            return $next($request);
+        }
+
+        // Skip cleaning for signed URL routes (signature validation requires exact query params).
+        // Also skip for saf-t download route which uses signed URLs.
+        if ($request->has('signature')
+            || $request->has('expires')
+            || $request->is('api/saf-t/download/*')) {
+            return $next($request);
+        }
+
+        $request->query->replace($this->recursivelyCleanParameters($request->query->all()));
+
+        if ($request->isJson()) {
+            $request->json()->replace($this->recursivelyCleanParameters($request->json()->all()));
+        } elseif (! in_array($request->getRealMethod(), ['GET', 'HEAD'], true)) {
+            $request->request->replace($this->recursivelyCleanParameters($request->request->all()));
         }
 
         return $next($request);
+    }
+
+    /**
+     * @param  array<mixed>  $parameters
+     * @return array<mixed>
+     */
+    private function recursivelyCleanParameters(array $parameters): array
+    {
+        $wasList = array_is_list($parameters);
+        $cleaned = [];
+
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
+                $nested = $this->recursivelyCleanParameters($value);
+
+                if ($nested === []) {
+                    continue;
+                }
+
+                $cleaned[$key] = $nested;
+
+                continue;
+            }
+
+            if ($this->shouldIncludeScalar($value)) {
+                $cleaned[$key] = $value;
+            }
+        }
+
+        return $wasList ? array_values($cleaned) : $cleaned;
+    }
+
+    private function shouldIncludeScalar(mixed $value): bool
+    {
+        if ($value === null || $value === '') {
+            return false;
+        }
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+
+            if ($trimmed === '' || strtolower($trimmed) === 'null') {
+                return false;
+            }
+        }
+
+        return is_scalar($value);
     }
 }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Feature/CleanApiQueryParametersMiddlewareTest.php
+++ b/tests/Feature/CleanApiQueryParametersMiddlewareTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Http\Middleware\CleanApiQueryParameters;
+use Illuminate\Http\Request;
+
+test('middleware strips string null from json body on api routes', function () {
+    $middleware = new CleanApiQueryParameters;
+
+    $base = Request::createFromBase(
+        Symfony\Component\HttpFoundation\Request::create(
+            '/api/example',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode([
+                'pos_session_id' => 'null',
+                'name' => 'ok',
+            ], JSON_THROW_ON_ERROR)
+        )
+    );
+
+    $middleware->handle($base, fn (Request $request) => response('ok'));
+
+    expect($base->input('pos_session_id'))->toBeNull()
+        ->and($base->input('name'))->toBe('ok');
+});
+
+test('middleware strips string null from nested json body keys', function () {
+    $middleware = new CleanApiQueryParameters;
+
+    $base = Request::createFromBase(
+        Symfony\Component\HttpFoundation\Request::create(
+            '/api/example',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'cart' => [
+                    'customer_id' => 'null',
+                    'total' => 100,
+                ],
+            ], JSON_THROW_ON_ERROR)
+        )
+    );
+
+    $middleware->handle($base, fn (Request $request) => response('ok'));
+
+    expect($base->input('cart.customer_id'))->toBeNull()
+        ->and($base->input('cart.total'))->toBe(100);
+});
+
+test('middleware reindexes json lists after removing string null entries', function () {
+    $middleware = new CleanApiQueryParameters;
+
+    $base = Request::createFromBase(
+        Symfony\Component\HttpFoundation\Request::create(
+            '/api/example',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'tags' => ['null', 'alpha', 'null', 'beta'],
+            ], JSON_THROW_ON_ERROR)
+        )
+    );
+
+    $middleware->handle($base, fn (Request $request) => response('ok'));
+
+    expect($base->input('tags'))->toBe(['alpha', 'beta']);
+});

--- a/tests/Feature/MeranoProxyControllerTest.php
+++ b/tests/Feature/MeranoProxyControllerTest.php
@@ -114,6 +114,36 @@ test('merano proxy rejects booking for a device with booking disabled', function
     $response->assertJsonPath('message', 'Booking is not enabled for this device.');
 });
 
+test('merano create booking does not error when pos_session_id is the string null', function () {
+    Addon::factory()->for($this->store)->create([
+        'type' => AddonType::MeranoBooking,
+        'is_active' => true,
+    ]);
+
+    $this->store->update([
+        'merano_base_url' => 'https://merano.example.com',
+        'merano_pos_api_token' => 'merano-token',
+    ]);
+
+    Http::fake([
+        'https://merano.example.com/api/pos/v1/bookings' => Http::response([
+            'booking_id' => 456,
+            'status' => 'pending',
+        ], 201),
+    ]);
+
+    $response = $this->postJson('/api/merano/v1/bookings', [
+        'pos_session_id' => 'null',
+        'event_id' => 10,
+        'seats' => ['A-1'],
+        'name' => 'Jane Doe',
+        'email' => 'jane@example.com',
+        'payment_type' => 'pos',
+    ]);
+
+    $response->assertCreated();
+});
+
 test('merano proxy forwards create booking request when configured', function () {
     Addon::factory()->for($this->store)->create([
         'type' => AddonType::MeranoBooking,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses GitHub issue #79 (Laravel Nightwatch nw-ref-40).

### Problem

Some API clients send the literal string `"null"` for absent bigint identifiers in JSON bodies. Existing middleware cleaned query strings only. Because `"null"` is truthy in PHP, code paths such as resolving a POS session from request input could call `Model::find()` with that string, which PostgreSQL rejects (`invalid input syntax for type bigint: "null"`).

### Changes

- Extend `CleanApiQueryParameters` to recursively drop empty strings, whitespace-only strings, and case-insensitive `"null"` scalars from JSON (`application/json`) payloads and from non-JSON form bodies (same semantics as query parameters). Signed URL routes remain skipped as before.
- Add Pest coverage for middleware behavior (nested keys and list reindexing) plus a Merano create-booking regression test using `pos_session_id` set to the string `null`.

### Other

- Align Filament Webflow package `Page::getUrl()` overrides with Filament v4 `Page::getUrl()` so the application and `php artisan test` bootstrap cleanly under PHP 8.4.

Refs #79
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b912794d-ac62-46a0-a76d-1f8fc69df23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b912794d-ac62-46a0-a76d-1f8fc69df23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

