### PR TITLE
Fix Stripe Connect charge.refund.updated Refund webhook handling

### DIFF
--- a/app/Actions/Webhooks/HandleRefundWebhook.php
+++ b/app/Actions/Webhooks/HandleRefundWebhook.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Actions\Webhooks;
+
+use Stripe\Charge;
+use Stripe\Refund;
+use Stripe\StripeClient;
+
+/**
+ * Stripe sends a Refund object for charge.refund.updated. We retrieve the updated Charge on the
+ * connected account and delegate to HandleChargeWebhook so ConnectedCharge stays in sync.
+ */
+class HandleRefundWebhook
+{
+    public function __construct(
+        private HandleChargeWebhook $handleChargeWebhook,
+    ) {}
+
+    public function handle(Refund $refund, string $eventType, ?string $accountId = null): void
+    {
+        $chargeId = $refund->charge;
+
+        if (! is_string($chargeId) || $chargeId === '') {
+            \Log::warning('Stripe refund webhook missing charge id', [
+                'refund_id' => $refund->id ?? null,
+                'event_type' => $eventType,
+            ]);
+
+            return;
+        }
+
+        $charge = $this->retrieveChargeFromStripe($chargeId, $accountId);
+
+        if ($charge === null) {
+            return;
+        }
+
+        $this->handleChargeWebhook->handle($charge, $eventType, $accountId);
+    }
+
+    protected function retrieveChargeFromStripe(string $chargeId, ?string $accountId): ?Charge
+    {
+        $secret = config('cashier.secret') ?? config('services.stripe.secret');
+
+        if (! is_string($secret) || $secret === '') {
+            \Log::error('Stripe secret not configured for refund webhook charge retrieval');
+
+            return null;
+        }
+
+        $stripe = new StripeClient($secret);
+
+        $requestOptions = [];
+
+        if ($accountId !== null && $accountId !== '') {
+            $requestOptions['stripe_account'] = $accountId;
+        }
+
+        try {
+            $charge = $stripe->charges->retrieve($chargeId, [], $requestOptions);
+        } catch (\Throwable $e) {
+            \Log::error('Failed to retrieve Stripe charge for refund webhook', [
+                'charge_id' => $chargeId,
+                'stripe_account_id' => $accountId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (! $charge instanceof Charge) {
+            \Log::warning('Stripe refund webhook charge retrieval returned unexpected type', [
+                'charge_id' => $chargeId,
+                'type' => get_debug_type($charge),
+            ]);
+
+            return null;
+        }
+
+        return $charge;
+    }
+}

--- a/app/Http/Controllers/Webhooks/StripeConnectWebhookController.php
+++ b/app/Http/Controllers/Webhooks/StripeConnectWebhookController.php
@@ -10,10 +10,14 @@ use App\Actions\Webhooks\HandlePaymentMethodWebhook;
 use App\Actions\Webhooks\HandlePayoutWebhook;
 use App\Actions\Webhooks\HandlePriceWebhook;
 use App\Actions\Webhooks\HandleProductWebhook;
+use App\Actions\Webhooks\HandleRefundWebhook;
 use App\Actions\Webhooks\HandleSubscriptionWebhook;
 use App\Actions\Webhooks\HandleTransferWebhook;
+use App\Models\Store;
+use App\Models\WebhookLog;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Schema;
 use Stripe\Account;
 use Stripe\Charge;
 use Stripe\Customer;
@@ -23,6 +27,7 @@ use Stripe\PaymentMethod;
 use Stripe\Payout;
 use Stripe\Price;
 use Stripe\Product;
+use Stripe\Refund;
 use Stripe\Subscription;
 use Stripe\Transfer;
 use Stripe\Webhook;
@@ -34,6 +39,7 @@ class StripeConnectWebhookController extends Controller
         Request $request,
         HandleStripeAccountWebhook $accountHandler,
         HandleChargeWebhook $chargeHandler,
+        HandleRefundWebhook $refundHandler,
         HandleCustomerWebhook $customerHandler,
         HandleSubscriptionWebhook $subscriptionHandler,
         HandleProductWebhook $productHandler,
@@ -371,7 +377,6 @@ class StripeConnectWebhookController extends Controller
                 case 'charge.failed':
                 case 'charge.captured':
                 case 'charge.refunded':
-                case 'charge.refund.updated':
                     $chargeObject = $event->data->object;
                     if (! $chargeObject instanceof Charge) {
                         $result['warnings'][] = "Unexpected webhook object for {$event->type}: ".get_debug_type($chargeObject);
@@ -385,6 +390,20 @@ class StripeConnectWebhookController extends Controller
                     $chargeHandler->handle($charge, $event->type, $accountId);
                     $result['processed'] = true;
                     $result['message'] = "Charge {$charge->id} ({$event->type}) processed";
+                    break;
+
+                case 'charge.refund.updated':
+                    $refundObject = $event->data->object;
+                    if (! $refundObject instanceof Refund) {
+                        $result['warnings'][] = "Unexpected webhook object for {$event->type}: ".get_debug_type($refundObject);
+                        $result['message'] = "Skipped {$event->type} because payload object was not a refund";
+
+                        break;
+                    }
+                    $refundHandler->handle($refundObject, $event->type, $accountId);
+                    $result['processed'] = true;
+                    $result['message'] = "Refund {$refundObject->id} ({$event->type}) processed";
+
                     break;
 
                     // Payment method events
@@ -487,18 +506,18 @@ class StripeConnectWebhookController extends Controller
         // Find store by account ID for logging
         $store = null;
         if ($accountId) {
-            $store = \App\Models\Store::where('stripe_account_id', $accountId)->first();
+            $store = Store::where('stripe_account_id', $accountId)->first();
         }
 
         // Save webhook log to database
         try {
             // Check if table exists before trying to save
-            if (! \Illuminate\Support\Facades\Schema::hasTable('webhook_logs')) {
+            if (! Schema::hasTable('webhook_logs')) {
                 \Log::warning('webhook_logs table does not exist - run migration first', [
                     'event_id' => $event->id,
                 ]);
             } else {
-                $webhookLog = \App\Models\WebhookLog::create([
+                $webhookLog = WebhookLog::create([
                     'store_id' => $store?->id,
                     'stripe_account_id' => $accountId,
                     'event_type' => $event->type,
@@ -522,7 +541,7 @@ class StripeConnectWebhookController extends Controller
 
                 // Cleanup old records (keep max 100 per store)
                 if ($store) {
-                    \App\Models\WebhookLog::cleanupOldRecords($store->id);
+                    WebhookLog::cleanupOldRecords($store->id);
                 }
             }
         } catch (\Throwable $e) {

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Unit/HandleRefundWebhookTest.php
+++ b/tests/Unit/HandleRefundWebhookTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Webhooks\HandleChargeWebhook;
+use App\Actions\Webhooks\HandleRefundWebhook;
+use Stripe\Charge;
+use Stripe\Refund;
+
+afterEach(function (): void {
+    Mockery::close();
+});
+
+it('retrieves charge and forwards to HandleChargeWebhook', function (): void {
+    $stubCharge = Charge::constructFrom([
+        'id' => 'ch_unit_refund123',
+        'payment_intent' => null,
+        'customer' => null,
+        'amount' => 5000,
+        'amount_refunded' => 2500,
+        'currency' => 'nok',
+        'status' => 'succeeded',
+        'description' => null,
+        'failure_code' => null,
+        'failure_message' => null,
+        'captured' => true,
+        'refunded' => false,
+        'paid' => true,
+        'created' => time(),
+        'metadata' => [],
+        'outcome' => [],
+        'on_behalf_of' => 'acct_unit_refund123',
+        'destination' => null,
+        'application_fee_amount' => null,
+        'payment_method_details' => ['type' => 'card'],
+    ]);
+
+    $chargeHandler = Mockery::mock(HandleChargeWebhook::class);
+    $chargeHandler->shouldReceive('handle')
+        ->once()
+        ->with(
+            Mockery::on(fn ($charge): bool => $charge instanceof Charge && $charge->id === 'ch_unit_refund123'),
+            'charge.refund.updated',
+            'acct_unit_refund123'
+        );
+
+    $sut = new class($chargeHandler, $stubCharge) extends HandleRefundWebhook
+    {
+        public function __construct(
+            HandleChargeWebhook $handleChargeWebhook,
+            private readonly Charge $stubCharge,
+        ) {
+            parent::__construct($handleChargeWebhook);
+        }
+
+        protected function retrieveChargeFromStripe(string $chargeId, ?string $accountId): ?Charge
+        {
+            expect($chargeId)->toBe('ch_unit_refund123')
+                ->and($accountId)->toBe('acct_unit_refund123');
+
+            return $this->stubCharge;
+        }
+    };
+
+    $refund = Refund::constructFrom([
+        'id' => 're_unit_refund123',
+        'object' => 'refund',
+        'charge' => 'ch_unit_refund123',
+        'amount' => 2500,
+        'currency' => 'nok',
+        'status' => 'succeeded',
+        'created' => time(),
+        'metadata' => [],
+    ]);
+
+    $sut->handle($refund, 'charge.refund.updated', 'acct_unit_refund123');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stripe sends a **Refund** object for `charge.refund.updated`, while `HandleChargeWebhook::handle()` requires a **Charge**. That mismatch caused production exceptions (Nightwatch **nw-ref-28**).

This change routes refund-update events separately: `HandleRefundWebhook` retrieves the charge on the connected account with `charges.retrieve` (using `stripe_account` when the Connect account ID is present) and delegates to the existing charge webhook logic so `ConnectedCharge` stays aligned with Stripe.

## Bootstrap fix

`filament-webflow` overrides of `Filament\Pages\Page::getUrl` were missing new Filament v4 parameters, which prevented Laravel from booting (`php artisan`, tests). Those signatures are updated to match the parent.

## Tests

```bash
php artisan test --compact tests/Unit/HandleRefundWebhookTest.php
```

## Tracking

- Issue: https://github.com/janiator/filament-pos-stripe/issues/81
- Nightwatch: nw-ref-28
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df6f2092-cfaf-4283-8e29-6c9006065256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df6f2092-cfaf-4283-8e29-6c9006065256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

