### PR TITLE
Fix duplicate insert race on store_stripe_balance_transactions (Nightwatch #45)

### DIFF
--- a/app/Actions/Stripe/SyncStoreStripeBalanceTransactionsFromStripe.php
+++ b/app/Actions/Stripe/SyncStoreStripeBalanceTransactionsFromStripe.php
@@ -4,6 +4,7 @@ namespace App\Actions\Stripe;
 
 use App\Models\Store;
 use App\Models\StoreStripeBalanceTransaction;
+use Carbon\Carbon;
 use Filament\Notifications\Notification;
 use Lanos\CashierConnect\Exceptions\AccountNotFoundException;
 use Stripe\StripeClient;
@@ -82,7 +83,7 @@ class SyncStoreStripeBalanceTransactionsFromStripe
 
                     $availableOn = null;
                     if (! empty($bt->available_on)) {
-                        $availableOn = \Carbon\Carbon::createFromTimestamp((int) $bt->available_on);
+                        $availableOn = Carbon::createFromTimestamp((int) $bt->available_on);
                     }
 
                     $data = [
@@ -106,16 +107,42 @@ class SyncStoreStripeBalanceTransactionsFromStripe
                         'reporting_category' => $bt->reporting_category ?? null,
                     ];
 
-                    $record = StoreStripeBalanceTransaction::query()
+                    $existed = StoreStripeBalanceTransaction::query()
                         ->where('stripe_balance_transaction_id', $bt->id)
-                        ->first();
+                        ->exists();
 
-                    if ($record) {
-                        $record->fill($data);
-                        $record->save();
+                    // Atomic upsert avoids unique violations when concurrent sync jobs race past a select-then-insert.
+                    $row = $data;
+                    $row['fee_details'] = $this->encodeNullableJsonArray($data['fee_details'] ?? null);
+                    $row['source_metadata'] = $this->encodeNullableJsonArray($data['source_metadata'] ?? null);
+
+                    StoreStripeBalanceTransaction::query()->upsert(
+                        [$row],
+                        ['stripe_balance_transaction_id'],
+                        [
+                            'store_id',
+                            'stripe_account_id',
+                            'type',
+                            'amount',
+                            'fee',
+                            'net',
+                            'currency',
+                            'status',
+                            'description',
+                            'stripe_charge_id',
+                            'stripe_payment_intent_id',
+                            'stripe_payout_id',
+                            'fee_details',
+                            'source_metadata',
+                            'stripe_created',
+                            'available_on',
+                            'reporting_category',
+                        ],
+                    );
+
+                    if ($existed) {
                         $result['updated']++;
                     } else {
-                        StoreStripeBalanceTransaction::query()->create($data);
                         $result['created']++;
                     }
                 } catch (Throwable $e) {
@@ -188,6 +215,18 @@ class SyncStoreStripeBalanceTransactionsFromStripe
         }
 
         return $out;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $value
+     */
+    protected function encodeNullableJsonArray(?array $value): ?string
+    {
+        if ($value === null || $value === []) {
+            return null;
+        }
+
+        return json_encode($value, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Unit/Actions/Stripe/SyncStoreStripeBalanceTransactionsJsonEncodeTest.php
+++ b/tests/Unit/Actions/Stripe/SyncStoreStripeBalanceTransactionsJsonEncodeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Actions\Stripe\SyncStoreStripeBalanceTransactionsFromStripe;
+
+it('prepares nullable json columns for query builder upsert bindings', function (): void {
+    $action = new SyncStoreStripeBalanceTransactionsFromStripe;
+    $method = (new ReflectionClass($action))->getMethod('encodeNullableJsonArray');
+    $method->setAccessible(true);
+
+    expect($method->invoke($action, null))->toBeNull()
+        ->and($method->invoke($action, []))->toBeNull()
+        ->and($method->invoke($action, ['k' => 'v']))->toBe('{"k":"v"}');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Nightwatch (**nw-ref-45**) reported a **unique violation** on `store_stripe_balance_transactions_stripe_balance_transaction_id` during [`SyncStoreStripeBalanceTransactionsJob`](app/Jobs/SyncStoreStripeBalanceTransactionsJob.php).

### Root cause

[`SyncStoreStripeBalanceTransactionsFromStripe`](app/Actions/Stripe/SyncStoreStripeBalanceTransactionsFromStripe.php) used a **check-then-insert** flow (`first()` → `create()`). Concurrent runs (scheduled sync plus payout webhook, `SyncEverythingFromStripeJob`, or manual Filament actions) could both observe no row and attempt `create()` for the same `txn_…` id, tripping the unique index on `stripe_balance_transaction_id`.

### Fix

Persist rows with **`upsert`** on `stripe_balance_transaction_id` so the write is **atomic** (PostgreSQL `ON CONFLICT DO UPDATE`). JSON columns are encoded for query-builder bindings. The existing `exists()` check is kept only for **created vs updated** counters (best-effort).

### Tests

- Added `tests/Unit/Actions/Stripe/SyncStoreStripeBalanceTransactionsJsonEncodeTest.php` for the JSON encoding helper used in the upsert payload.

### Additional note

`packages/filament-webflow` had **`Page::getUrl` signatures incompatible** with Filament v4’s parent method, causing a PHP fatal on application bootstrap and blocking `php artisan test`. Updated [`WebflowCollectionItemsPage`](packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php) and [`WebflowItemEditPage`](packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php) to match the parent signature and forward the new parameters.

Closes #83 (tracking). Nightwatch ref: **#45**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15950327-db99-4e47-8c5a-1829f1cce4aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15950327-db99-4e47-8c5a-1829f1cce4aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

