### PR TITLE
Fix Stripe unknown parameters on Product create (service-only unit_label)

### DIFF
--- a/app/Actions/ConnectedProducts/CreateConnectedProductInStripe.php
+++ b/app/Actions/ConnectedProducts/CreateConnectedProductInStripe.php
@@ -40,73 +40,7 @@ class CreateConnectedProductInStripe
         $stripe = new StripeClient($secret);
 
         try {
-            $createData = [
-                'name' => $product->name,
-                'type' => $product->type ?? 'service',
-            ];
-
-            // Add optional fields if they exist
-            if ($product->description !== null) {
-                $createData['description'] = $product->description;
-            }
-
-            if ($product->active !== null) {
-                $createData['active'] = $product->active;
-            }
-
-            if ($product->url !== null) {
-                $createData['url'] = $product->url;
-            }
-
-            if ($product->images !== null && is_array($product->images) && count($product->images) > 0) {
-                $createData['images'] = array_values(array_filter(array_slice($product->images, 0, 8), 'is_string'));
-            }
-
-            if ($product->shippable !== null) {
-                $createData['shippable'] = $product->shippable;
-            }
-
-            if ($product->statement_descriptor !== null) {
-                $createData['statement_descriptor'] = $product->statement_descriptor;
-            }
-
-            if ($product->tax_code !== null) {
-                $createData['tax_code'] = $product->tax_code;
-            }
-
-            if ($product->unit_label !== null) {
-                $createData['unit_label'] = $product->unit_label;
-            }
-
-            if ($product->package_dimensions !== null && is_array($product->package_dimensions)) {
-                $createData['package_dimensions'] = $product->package_dimensions;
-            }
-
-            if ($product->product_meta !== null && is_array($product->product_meta)) {
-                // Ensure all metadata values are strings
-                $metadata = [];
-                foreach ($product->product_meta as $key => $value) {
-                    if (! is_string($key) ||
-                        str_contains($key, "\0") ||
-                        str_contains($key, '*') ||
-                        str_contains($key, '_opts') ||
-                        str_starts_with($key, '_')) {
-                        continue;
-                    }
-
-                    if (is_string($value)) {
-                        $metadata[$key] = $value;
-                    } elseif (is_scalar($value)) {
-                        $metadata[$key] = (string) $value;
-                    } elseif (! is_null($value)) {
-                        $metadata[$key] = json_encode($value);
-                    }
-                }
-
-                if (! empty($metadata)) {
-                    $createData['metadata'] = $metadata;
-                }
-            }
+            $createData = $this->buildStripeProductCreatePayload($product);
 
             // Create product in Stripe
             $stripeProduct = $stripe->products->create(
@@ -135,5 +69,85 @@ class CreateConnectedProductInStripe
 
             return null;
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildStripeProductCreatePayload(ConnectedProduct $product): array
+    {
+        $createData = [
+            'name' => $product->name,
+            'type' => $product->type ?? 'service',
+        ];
+
+        // Add optional fields if they exist
+        if ($product->description !== null) {
+            $createData['description'] = $product->description;
+        }
+
+        if ($product->active !== null) {
+            $createData['active'] = $product->active;
+        }
+
+        if ($product->url !== null) {
+            $createData['url'] = $product->url;
+        }
+
+        if ($product->images !== null && is_array($product->images) && count($product->images) > 0) {
+            $createData['images'] = array_values(array_filter(array_slice($product->images, 0, 8), 'is_string'));
+        }
+
+        if ($product->shippable !== null) {
+            $createData['shippable'] = $product->shippable;
+        }
+
+        if ($product->statement_descriptor !== null) {
+            $createData['statement_descriptor'] = $product->statement_descriptor;
+        }
+
+        if ($product->tax_code !== null) {
+            $createData['tax_code'] = $product->tax_code;
+        }
+
+        $stripeProductType = $product->type ?? 'service';
+
+        if (is_string($stripeProductType)
+            && strtolower($stripeProductType) === 'service'
+            && $product->unit_label !== null) {
+            $createData['unit_label'] = $product->unit_label;
+        }
+
+        if ($product->package_dimensions !== null && is_array($product->package_dimensions)) {
+            $createData['package_dimensions'] = $product->package_dimensions;
+        }
+
+        if ($product->product_meta !== null && is_array($product->product_meta)) {
+            // Ensure all metadata values are strings
+            $metadata = [];
+            foreach ($product->product_meta as $key => $value) {
+                if (! is_string($key) ||
+                    str_contains($key, "\0") ||
+                    str_contains($key, '*') ||
+                    str_contains($key, '_opts') ||
+                    str_starts_with($key, '_')) {
+                    continue;
+                }
+
+                if (is_string($value)) {
+                    $metadata[$key] = $value;
+                } elseif (is_scalar($value)) {
+                    $metadata[$key] = (string) $value;
+                } elseif (! is_null($value)) {
+                    $metadata[$key] = json_encode($value);
+                }
+            }
+
+            if (! empty($metadata)) {
+                $createData['metadata'] = $metadata;
+            }
+        }
+
+        return $createData;
     }
 }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,18 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
-    {
-        // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+    public static function getUrl(
+        array $parameters = [],
+        bool $isAbsolute = true,
+        ?string $panel = null,
+        ?Model $tenant = null,
+        bool $shouldGuessMissingParameters = false,
+        ?string $configuration = null,
+    ): string {
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,20 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
-    {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+    public static function getUrl(
+        array $parameters = [],
+        bool $isAbsolute = true,
+        ?string $panel = null,
+        ?Model $tenant = null,
+        bool $shouldGuessMissingParameters = false,
+        ?string $configuration = null,
+    ): string {
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripePayloadTest.php
+++ b/tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripePayloadTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Actions\ConnectedProducts\CreateConnectedProductInStripe;
+use App\Models\ConnectedProduct;
+
+it('buildStripeProductCreatePayload omits unit_label for good type products', function (): void {
+    $payloadTester = new class extends CreateConnectedProductInStripe
+    {
+        public function testPayload(ConnectedProduct $product): array
+        {
+            return $this->buildStripeProductCreatePayload($product);
+        }
+    };
+
+    $product = new ConnectedProduct([
+        'name' => 'Weight bag',
+        'stripe_account_id' => 'acct_test_good',
+        'type' => 'good',
+        'unit_label' => 'stk',
+    ]);
+
+    $payload = $payloadTester->testPayload($product);
+
+    expect($payload['type'])->toBe('good')
+        ->and($payload)->not->toHaveKey('unit_label');
+});
+
+it('buildStripeProductCreatePayload includes unit_label for service type products', function (): void {
+    $payloadTester = new class extends CreateConnectedProductInStripe
+    {
+        public function testPayload(ConnectedProduct $product): array
+        {
+            return $this->buildStripeProductCreatePayload($product);
+        }
+    };
+
+    $product = new ConnectedProduct([
+        'name' => 'Hourly tune-up',
+        'stripe_account_id' => 'acct_test_service',
+        'type' => 'service',
+        'unit_label' => 'hour',
+    ]);
+
+    $payload = $payloadTester->testPayload($product);
+
+    expect($payload['type'])->toBe('service')
+        ->and($payload)->toHaveKey('unit_label')
+        ->and($payload['unit_label'])->toBe('hour');
+});
+
+it('buildStripeProductCreatePayload includes unit_label when type defaults to service', function (): void {
+    $payloadTester = new class extends CreateConnectedProductInStripe
+    {
+        public function testPayload(ConnectedProduct $product): array
+        {
+            return $this->buildStripeProductCreatePayload($product);
+        }
+    };
+
+    $product = new ConnectedProduct([
+        'name' => 'Default type product',
+        'stripe_account_id' => 'acct_test_default_service',
+        'unit_label' => 'seat',
+    ]);
+
+    $payload = $payloadTester->testPayload($product);
+
+    expect($payload['type'])->toBe('service')
+        ->and($payload['unit_label'])->toBe('seat');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses Stripe `InvalidRequestException` / “Received unknown parameter(s)” from Nightwatch (nw-ref-4).

## Root cause
`ProductsController@store` always assigns `unit_label` (defaults to `'stk'`). `CreateConnectedProductInStripe` forwarded that attribute to Stripe for every product type. Stripe only permits `unit_label` when product `type` is `service`. Creating a **`good`** product therefore sent invalid parameters—a common FlutterFlow/API path (`type: good`).

## Changes
- `CreateConnectedProductInStripe`: include `unit_label` in the Stripe create payload only when the effective Stripe type is `service` (same rule as `UpdateConnectedProductToStripe`). Payload construction lives in `buildStripeProductCreatePayload()` for clearer testing.
- Regression tests in `tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripePayloadTest.php`.

## Filament-Webflow compat
Upstream `Filament\Pages\Page::getUrl()` gained `$shouldGuessMissingParameters` and `$configuration`. Overrides in local `packages/filament-webflow` were updated so the application boots and PHPUnit can initialize.

Tracks #85 / Nightwatch nw-ref-4.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e222fc6-9f71-421e-805d-14080478a610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e222fc6-9f71-421e-805d-14080478a610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

