### PR TITLE
Fix NOT NULL violation on connected_payment_methods.stripe_customer_id (Nightwatch nw-ref-9)

### DIFF
--- a/app/Actions/Webhooks/HandlePaymentMethodWebhook.php
+++ b/app/Actions/Webhooks/HandlePaymentMethodWebhook.php
@@ -37,12 +37,17 @@ class HandlePaymentMethodWebhook
             ->first();
 
         if ($isDetachEvent) {
-            $resolvedStripeCustomerId = null;
-        } else {
-            $resolvedStripeCustomerId = $paymentMethod->customer ?: $existingPaymentMethod?->stripe_customer_id;
+            if ($existingPaymentMethod) {
+                $existingPaymentMethod->delete();
+            }
+
+            return;
         }
 
-        if (! $isDetachEvent && ! $resolvedStripeCustomerId) {
+        $resolvedStripeCustomerId = $this->resolveStripeCustomerId($paymentMethod)
+            ?? $existingPaymentMethod?->stripe_customer_id;
+
+        if (! $resolvedStripeCustomerId) {
             \Log::warning('Skipping payment method webhook because stripe customer id is missing', [
                 'payment_method_id' => $paymentMethod->id,
                 'event_type' => $eventType,
@@ -71,11 +76,26 @@ class HandlePaymentMethodWebhook
             return;
         }
 
-        if ($isDetachEvent) {
-            return;
+        ConnectedPaymentMethod::query()->create($data);
+    }
+
+    private function resolveStripeCustomerId(PaymentMethod $paymentMethod): ?string
+    {
+        $customer = $paymentMethod->customer ?? null;
+
+        if (is_string($customer) && $customer !== '') {
+            return $customer;
         }
 
-        ConnectedPaymentMethod::query()->create($data);
+        if (is_object($customer) && isset($customer->id) && is_string($customer->id) && $customer->id !== '') {
+            return $customer->id;
+        }
+
+        if (is_array($customer) && isset($customer['id']) && is_string($customer['id']) && $customer['id'] !== '') {
+            return $customer['id'];
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Feature/WebhookAndObserverPosSessionTest.php
+++ b/tests/Feature/WebhookAndObserverPosSessionTest.php
@@ -10,6 +10,7 @@ use App\Models\PosSession;
 use App\Models\Store;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Stripe\Charge;
+use Stripe\PaymentMethod;
 
 uses(RefreshDatabase::class);
 
@@ -168,7 +169,7 @@ it('does not overwrite existing payment method customer with null value', functi
         'card_exp_year' => 2030,
     ]);
 
-    $paymentMethod = \Stripe\PaymentMethod::constructFrom([
+    $paymentMethod = PaymentMethod::constructFrom([
         'id' => $existing->stripe_payment_method_id,
         'customer' => null,
         'type' => 'card',
@@ -192,4 +193,75 @@ it('does not overwrite existing payment method customer with null value', functi
     expect($existing->stripe_customer_id)->toBe('cus_existing_123')
         ->and($existing->card_brand)->toBe('mastercard')
         ->and($existing->card_last4)->toBe('4444');
+});
+
+it('deletes connected payment method on detach webhook instead of nulling stripe_customer_id', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+
+    $existing = ConnectedPaymentMethod::query()->create([
+        'stripe_payment_method_id' => 'pm_'.uniqid(),
+        'stripe_account_id' => $store->stripe_account_id,
+        'stripe_customer_id' => 'cus_to_detach_123',
+        'type' => 'card',
+        'card_brand' => 'visa',
+        'card_last4' => '4242',
+        'card_exp_month' => 1,
+        'card_exp_year' => 2030,
+    ]);
+
+    $paymentMethod = PaymentMethod::constructFrom([
+        'id' => $existing->stripe_payment_method_id,
+        'customer' => null,
+        'type' => 'card',
+        'card' => [
+            'brand' => 'visa',
+            'last4' => '4242',
+            'exp_month' => 1,
+            'exp_year' => 2030,
+        ],
+        'metadata' => [],
+    ]);
+
+    app(HandlePaymentMethodWebhook::class)->handle(
+        $paymentMethod,
+        'payment_method.detached',
+        $store->stripe_account_id
+    );
+
+    expect(ConnectedPaymentMethod::query()->whereKey($existing->id)->exists())->toBeFalse();
+});
+
+it('persists payment method when customer is an expanded Stripe object', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+    $cusId = 'cus_expanded_'.uniqid();
+
+    $paymentMethod = PaymentMethod::constructFrom([
+        'id' => 'pm_'.uniqid(),
+        'customer' => [
+            'object' => 'customer',
+            'id' => $cusId,
+        ],
+        'type' => 'card',
+        'card' => [
+            'brand' => 'amex',
+            'last4' => '0005',
+            'exp_month' => 6,
+            'exp_year' => 2033,
+        ],
+        'metadata' => [],
+    ]);
+
+    app(HandlePaymentMethodWebhook::class)->handle(
+        $paymentMethod,
+        'payment_method.attached',
+        $store->stripe_account_id
+    );
+
+    $row = ConnectedPaymentMethod::query()
+        ->where('stripe_payment_method_id', $paymentMethod->id)
+        ->first();
+
+    expect($row)->not->toBeNull()
+        ->and($row->stripe_customer_id)->toBe($cusId)
+        ->and($row->card_brand)->toBe('amex');
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes handling of Stripe Connect `payment_method.*` webhooks so we never persist `stripe_customer_id = null` on `connected_payment_methods`.

**Root cause:** For `payment_method.detached`, the handler updated existing rows with `stripe_customer_id` set to `null`, which violates the column’s NOT NULL constraint (same class of error as a failed insert from the database’s perspective).

**Change:** On detach, delete the local `ConnectedPaymentMethod` if present. For other events, resolve the Stripe customer id from a string id, expanded customer object, or array-shaped payload before create/update; skip and log when it cannot be resolved.

Tests added/extended in `tests/Feature/WebhookAndObserverPosSessionTest.php` (detach deletes row; expanded customer id persists).

Tracking: closes #87 (Nightwatch ref nw-ref-9 / #9).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abedc3f2-97b4-47ad-af44-554d183d7558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abedc3f2-97b4-47ad-af44-554d183d7558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

