### PR TITLE
Fix duplicate ConnectedCharge insert on Stripe webhook/sync (stripe_charge_id unique)

### DIFF
--- a/app/Actions/ConnectedCharges/SyncConnectedChargesFromStripe.php
+++ b/app/Actions/ConnectedCharges/SyncConnectedChargesFromStripe.php
@@ -101,39 +101,37 @@ class SyncConnectedChargesFromStripe
                         continue;
                     }
 
-                    // Find by stripe_charge_id only (since it's unique)
-                    // The same charge might exist with a different stripe_account_id
-                    $chargeRecord = ConnectedCharge::where('stripe_charge_id', $charge->id)->first();
+                    $existing = ConnectedCharge::where('stripe_charge_id', $charge->id)->first();
 
-                    if ($chargeRecord) {
-                        // Preserve POS-specific fields that don't come from Stripe
-                        // These fields should never be overwritten by Stripe sync
-                        $preservedFields = [
-                            'pos_session_id' => $chargeRecord->pos_session_id,
-                            'transaction_code' => $chargeRecord->transaction_code,
-                            'payment_code' => $chargeRecord->payment_code,
-                            'tip_amount' => $chargeRecord->tip_amount,
-                            'article_group_code' => $chargeRecord->article_group_code,
-                        ];
+                    $preservedFields = [
+                        'pos_session_id' => $existing?->pos_session_id,
+                        'transaction_code' => $existing?->transaction_code,
+                        'payment_code' => $existing?->payment_code,
+                        'tip_amount' => $existing?->tip_amount,
+                        'article_group_code' => $existing?->article_group_code,
+                    ];
 
-                        // Update existing record - ensure stripe_account_id is set correctly
-                        $chargeRecord->fill($data);
-                        // Explicitly set stripe_account_id to ensure it's updated if it changed
-                        $chargeRecord->stripe_account_id = $stripeAccountId;
+                    $chargeRecord = ConnectedCharge::updateOrCreate(
+                        ['stripe_charge_id' => $charge->id],
+                        $data
+                    );
 
-                        // Restore preserved POS-specific fields
-                        foreach ($preservedFields as $field => $value) {
-                            if ($value !== null) {
-                                $chargeRecord->$field = $value;
-                            }
+                    $wasNew = $chargeRecord->wasRecentlyCreated;
+
+                    foreach ($preservedFields as $field => $value) {
+                        if ($value !== null) {
+                            $chargeRecord->$field = $value;
                         }
+                    }
 
+                    if ($chargeRecord->isDirty()) {
                         $chargeRecord->save();
-                        $result['updated']++;
-                    } else {
-                        // Create new record
-                        ConnectedCharge::create($data);
+                    }
+
+                    if ($wasNew) {
                         $result['created']++;
+                    } else {
+                        $result['updated']++;
                     }
                 } catch (Throwable $e) {
                     $result['errors'][] = "Charge {$charge->id}: {$e->getMessage()}";

--- a/app/Actions/Webhooks/HandleChargeWebhook.php
+++ b/app/Actions/Webhooks/HandleChargeWebhook.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Webhooks;
 
+use App\Jobs\PushTicketCountsToWebflow;
 use App\Models\ConnectedCharge;
 use App\Models\ConnectedPaymentLink;
 use App\Models\EventTicket;
@@ -100,25 +101,26 @@ class HandleChargeWebhook
             }
         }
 
-        // No row found by payment_intent_id: updateOrCreate by (stripe_charge_id, stripe_account_id)
         if (! $chargeRecord) {
-            $chargeRecord = ConnectedCharge::where('stripe_charge_id', $charge->id)
-                ->where('stripe_account_id', $store->stripe_account_id)
-                ->first();
+            $existingSnapshot = ConnectedCharge::where('stripe_charge_id', $charge->id)->first();
 
-            $wasCreated = false;
-            if ($chargeRecord) {
-                $chargeRecord->fill($data);
-                $chargeRecord->stripe_account_id = $store->stripe_account_id;
+            $chargeRecord = ConnectedCharge::updateOrCreate(
+                ['stripe_charge_id' => $charge->id],
+                $data
+            );
+
+            $wasCreated = $chargeRecord->wasRecentlyCreated;
+
+            if ($existingSnapshot !== null) {
                 foreach (self::PRESERVED_POS_FIELDS as $field) {
-                    if ($chargeRecord->getRawOriginal($field) !== null) {
-                        $chargeRecord->$field = $chargeRecord->getRawOriginal($field);
+                    if ($existingSnapshot->getRawOriginal($field) !== null) {
+                        $chargeRecord->$field = $existingSnapshot->getRawOriginal($field);
                     }
                 }
-                $chargeRecord->save();
-            } else {
-                $chargeRecord = ConnectedCharge::create($data);
-                $wasCreated = true;
+
+                if ($chargeRecord->isDirty()) {
+                    $chargeRecord->save();
+                }
             }
 
             \Log::info('Charge webhook processed successfully', [
@@ -184,7 +186,7 @@ class HandleChargeWebhook
                 'quantity' => $quantity,
             ]);
 
-            \App\Jobs\PushTicketCountsToWebflow::dispatch($eventTicket);
+            PushTicketCountsToWebflow::dispatch($eventTicket);
         } catch (\Throwable $e) {
             \Log::warning('Event ticket purchase handling failed', [
                 'charge_id' => $charge->id,

--- a/tests/Feature/Actions/ConnectedCharges/SyncConnectedChargesFromStripeTest.php
+++ b/tests/Feature/Actions/ConnectedCharges/SyncConnectedChargesFromStripeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Actions\ConnectedCharges\SyncConnectedChargesFromStripe;
+use App\Models\ConnectedCharge;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Stripe\Charge;
+use Stripe\Collection;
+use Stripe\StripeClient;
+
+uses(RefreshDatabase::class);
+
+afterEach(function () {
+    Mockery::close();
+});
+
+function makeStripeChargeForConnectedChargeSync(string $chargeId, string $onBehalfOfAccountId): Charge
+{
+    return Charge::constructFrom([
+        'id' => $chargeId,
+        'customer' => null,
+        'payment_intent' => 'pi_'.uniqid(),
+        'amount' => 5000,
+        'amount_refunded' => 0,
+        'currency' => 'nok',
+        'status' => 'succeeded',
+        'description' => null,
+        'failure_code' => null,
+        'failure_message' => null,
+        'captured' => true,
+        'refunded' => false,
+        'paid' => true,
+        'created' => time(),
+        'metadata' => [],
+        'outcome' => null,
+        'on_behalf_of' => $onBehalfOfAccountId,
+        'application_fee_amount' => null,
+        'payment_method_details' => ['type' => 'card'],
+    ]);
+}
+
+it('sync upserts by stripe_charge_id so a second run does not insert a duplicate', function () {
+    $accountId = 'acct_sync_'.uniqid();
+    $store = Store::factory()->create(['stripe_account_id' => $accountId]);
+    $chargeId = 'ch_sync_'.uniqid();
+
+    $stripeCharge = makeStripeChargeForConnectedChargeSync($chargeId, $accountId);
+    $collection = Collection::constructFrom([
+        'object' => 'list',
+        'data' => [$stripeCharge],
+        'has_more' => false,
+        'url' => '/v1/charges',
+    ]);
+
+    $mockCharges = Mockery::mock();
+    $mockCharges->shouldReceive('all')
+        ->twice()
+        ->andReturn($collection);
+
+    $mockStripe = Mockery::mock('overload:'.StripeClient::class);
+    $mockStripe->shouldReceive('__construct')
+        ->twice()
+        ->andReturnSelf();
+    $mockStripe->charges = $mockCharges;
+
+    $action = new SyncConnectedChargesFromStripe;
+
+    $result1 = $action($store);
+    $result2 = $action($store);
+
+    expect(ConnectedCharge::where('stripe_charge_id', $chargeId)->count())->toBe(1)
+        ->and($result1['created'])->toBe(1)
+        ->and($result1['updated'])->toBe(0)
+        ->and($result2['created'])->toBe(0)
+        ->and($result2['updated'])->toBe(1);
+});

--- a/tests/Feature/WebhookAndObserverPosSessionTest.php
+++ b/tests/Feature/WebhookAndObserverPosSessionTest.php
@@ -10,6 +10,7 @@ use App\Models\PosSession;
 use App\Models\Store;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Stripe\Charge;
+use Stripe\PaymentMethod;
 
 uses(RefreshDatabase::class);
 
@@ -90,6 +91,44 @@ it('merges webhook into existing charge by payment_intent_id and preserves pos_s
     expect(ConnectedCharge::where('stripe_payment_intent_id', $paymentIntentId)->count())->toBe(1);
 });
 
+it('upserts by stripe_charge_id when the existing row has a mismatched stripe_account_id', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+    $staleAccountId = 'acct_stale_'.uniqid();
+    $paymentIntentId = 'pi_'.uniqid();
+    $stripeChargeId = 'ch_'.uniqid();
+
+    ConnectedCharge::factory()->create([
+        'stripe_charge_id' => $stripeChargeId,
+        'stripe_account_id' => $staleAccountId,
+        'stripe_payment_intent_id' => null,
+        'pos_session_id' => null,
+        'amount' => 1000,
+        'status' => 'pending',
+        'paid' => false,
+    ]);
+
+    $stripeCharge = makeStripeChargeForWebhook([
+        'id' => $stripeChargeId,
+        'payment_intent' => $paymentIntentId,
+        'amount' => 6000,
+        'on_behalf_of' => $store->stripe_account_id,
+    ]);
+
+    app(HandleChargeWebhook::class)->handle(
+        $stripeCharge,
+        'charge.succeeded',
+        $store->stripe_account_id
+    );
+
+    expect(ConnectedCharge::where('stripe_charge_id', $stripeChargeId)->count())->toBe(1);
+
+    $row = ConnectedCharge::where('stripe_charge_id', $stripeChargeId)->first();
+    expect($row)->not->toBeNull()
+        ->and($row->stripe_account_id)->toBe($store->stripe_account_id)
+        ->and($row->amount)->toBe(6000)
+        ->and($row->stripe_payment_intent_id)->toBe($paymentIntentId);
+});
+
 it('does not create POS events when ConnectedCharge has null pos_session_id', function () {
     $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
 
@@ -168,7 +207,7 @@ it('does not overwrite existing payment method customer with null value', functi
         'card_exp_year' => 2030,
     ]);
 
-    $paymentMethod = \Stripe\PaymentMethod::constructFrom([
+    $paymentMethod = PaymentMethod::constructFrom([
         'id' => $existing->stripe_payment_method_id,
         'customer' => null,
         'type' => 'card',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/janiator/filament-pos-stripe/issues/89

**Nightwatch:** [nw-ref-29](https://nightwatch.laravel.com) (internal ref #29) — `connected_charges_stripe_charge_id_unique` during webhook-related sync.

### Cause
`connected_charges` enforces a partial unique index on `stripe_charge_id` (non-null). The charge webhook fallback looked up rows with both `stripe_charge_id` and `stripe_account_id`; if a row already existed for that Stripe charge but `stripe_account_id` on the row was stale or wrong, the handler fell through to `ConnectedCharge::create()` and Postgres raised a unique violation. Filament/manual sync used a plain `create()` on the “not found” branch, which had the same failure mode under retries or races.

### Fix
- `HandleChargeWebhook`: after the payment-intent merge path, upsert with `ConnectedCharge::updateOrCreate(['stripe_charge_id' => $charge->id], $data)` and re-apply POS-only fields from a pre-update snapshot when needed.
- `SyncConnectedChargesFromStripe`: same upsert keyed on `stripe_charge_id`, preserving POS fields and keeping accurate created/updated counts.

### How to verify
```bash
php artisan test --compact tests/Feature/WebhookAndObserverPosSessionTest.php tests/Feature/Actions/ConnectedCharges/SyncConnectedChargesFromStripeTest.php
```

The webhook test covers a mismatched `stripe_account_id` on an existing row (previously would try a second insert). The sync test runs the action twice with a mocked Stripe client and asserts a single DB row and `created`/`updated` tallies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9acfb23-81d7-4a33-898d-4c06688a2314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9acfb23-81d7-4a33-898d-4c06688a2314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

