### PR TITLE
fix: connected customer phone column integer overflow (Nightwatch NW #35)

### DIFF
--- a/app/Models/ConnectedCustomer.php
+++ b/app/Models/ConnectedCustomer.php
@@ -28,6 +28,7 @@ class ConnectedCustomer extends Model
 
     protected $casts = [
         'address' => 'array',
+        'phone' => 'string',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2026_05_16_220000_ensure_stripe_connected_customer_mappings_phone_is_string.php
+++ b/database/migrations/2026_05_16_220000_ensure_stripe_connected_customer_mappings_phone_is_string.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Phone numbers must not use a 32-bit integer column: values such as 9545559600 overflow
+     * PostgreSQL integer and raise QueryException. Store as varchar instead.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('stripe_connected_customer_mappings', 'phone')) {
+            return;
+        }
+
+        $driver = DB::getDriverName();
+
+        if ($driver === 'pgsql') {
+            DB::statement('ALTER TABLE stripe_connected_customer_mappings ALTER COLUMN phone TYPE VARCHAR(255) USING (phone::text)');
+
+            return;
+        }
+
+        Schema::table('stripe_connected_customer_mappings', function (Blueprint $table) {
+            $table->string('phone', 255)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Intentionally omitted: reverting phone to integer would truncate or reject data.
+    }
+};

--- a/tests/Feature/ConnectedCustomerPhoneStorageTest.php
+++ b/tests/Feature/ConnectedCustomerPhoneStorageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\ConnectedCustomer;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+test('connected customer persists ten digit phone numbers that exceed 32-bit integer range', function () {
+    $user = User::factory()->create();
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_test_phone']);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->postJson('/api/customers', [
+        'name' => 'Phone Overflow Test',
+        'email' => 'phone-overflow-test@example.com',
+        'phone' => '9545559600',
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonPath('phone', '9545559600');
+
+    $customerId = $response->json('id');
+
+    $this->assertDatabaseHas('stripe_connected_customer_mappings', [
+        'id' => $customerId,
+        'phone' => '9545559600',
+    ]);
+});
+
+test('stripe_connected_customer_mappings phone column is not a 32-bit integer on pgsql', function () {
+    if (DB::getDriverName() !== 'pgsql') {
+        $this->markTestSkipped('PostgreSQL-only: verifies migrated phone column type.');
+    }
+
+    $row = DB::selectOne(
+        "select data_type from information_schema.columns where table_schema = current_schema() and table_name = 'stripe_connected_customer_mappings' and column_name = 'phone'"
+    );
+
+    expect($row)->not->toBeNull();
+    expect($row->data_type)->not->toBe('integer')
+        ->and($row->data_type)->toBeIn(['character varying', 'text']);
+});
+
+test('connected customer model accepts numeric phone input from request as string storage', function () {
+    $customer = ConnectedCustomer::withoutEvents(function () {
+        return ConnectedCustomer::query()->create([
+            'stripe_account_id' => 'acct_numeric_phone',
+            'stripe_customer_id' => 'cus_numeric_phone',
+            'name' => 'Numeric phone',
+            'email' => null,
+            'phone' => 9545559600,
+        ]);
+    });
+
+    expect($customer->fresh()->phone)->toBe('9545559600');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks https://github.com/janiator/filament-pos-stripe/issues/91 (Nightwatch **nw-ref-35** / NW #35).

**Cause**  
`stripe_connected_customer_mappings.phone` was a PostgreSQL **integer** in production. Values such as `9545559600` exceed 32-bit signed integer range, triggering `QueryException: value out of range for type integer`.

**Fix**  
- Migration alters `phone` to `VARCHAR(255)` on PostgreSQL (`USING (phone::text)` so existing integer or text data converts safely). Other drivers use Laravel `string()->nullable()->change()`.  
- `ConnectedCustomer` casts `phone` to **string** so numeric values from the API or Stripe are normalized before persistence.

**How to verify**  
1. `php artisan migrate`  
2. `php artisan test --compact tests/Feature/ConnectedCustomerPhoneStorageTest.php`  

On PostgreSQL, the suite asserts the column type is not `integer` and that `9545559600` round-trips via the API and direct model create.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0aee03d0-70d6-4c33-9ace-fd2aa774569e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0aee03d0-70d6-4c33-9ace-fd2aa774569e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

