### PR TITLE
Fix Shield Role Filament tenancy (Nightwatch nw-ref-26 / #93)

### DIFF
--- a/app/Filament/Resources/Shield/Roles/RoleResource.php
+++ b/app/Filament/Resources/Shield/Roles/RoleResource.php
@@ -46,6 +46,21 @@ class RoleResource extends Resource
      */
     protected static bool $isScopedToTenant = false;
 
+    public static function isScopedToTenant(): bool
+    {
+        return false;
+    }
+
+    public static function registerTenancyModelGlobalScope(Panel $panel): void
+    {
+        // Spatie Permission roles are global; omit Filament tenancy global scope registration.
+    }
+
+    public static function observeTenancyModelCreation(Panel $panel): void
+    {
+        // Never associate/sync roles with the current tenant — Role has no `store` relationship.
+    }
+
     public static function form(Schema $schema): Schema
     {
         return $schema

--- a/tests/Feature/Filament/RoleResourceTenantScopeRegistrationTest.php
+++ b/tests/Feature/Filament/RoleResourceTenantScopeRegistrationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Shield\Roles\RoleResource;
+use App\Models\Store;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+    $this->store = Store::factory()->create();
+});
+
+it('does not register Filament tenant global scopes on Spatie Permission roles', function (): void {
+    $panel = Filament::getPanel('app');
+
+    expect(Role::hasGlobalScope($panel->getTenancyScopeName()))->toBeFalse()
+        ->and(RoleResource::isScopedToTenant())->toBeFalse();
+});
+
+it('does not crash when querying the shield Role resource eloquent builder with an active tenant', function (): void {
+    Filament::setCurrentPanel('app');
+    Filament::setTenant($this->store);
+    Filament::bootCurrentPanel();
+
+    expect(fn (): int => RoleResource::getEloquentQuery()->count())->not->toThrow(Throwable::class);
+});

--- a/tests/Unit/RoleResourceTenancyTest.php
+++ b/tests/Unit/RoleResourceTenancyTest.php
@@ -4,4 +4,11 @@ use App\Filament\Resources\Shield\Roles\RoleResource;
 
 it('does not scope shield roles to the Filament tenant', function (): void {
     expect(RoleResource::isScopedToTenant())->toBeFalse();
+
+    $class = new ReflectionClass(RoleResource::class);
+
+    foreach (['registerTenancyModelGlobalScope', 'observeTenancyModelCreation'] as $methodName) {
+        expect($class->hasMethod($methodName))->toBeTrue();
+        expect($class->getMethod($methodName)->getDeclaringClass()->getName())->toBe(RoleResource::class);
+    }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Tracks

- Closes expectations from https://github.com/janiator/filament-pos-stripe/issues/93
- Nightwatch incident: **nw-ref-26** (internal ref `#26`)

## Cause

The `app` panel uses Filament tenancy with `Store` as the tenant model, so `Filament::getTenantOwnershipRelationshipName()` resolves to **`store`**. Tenancy bootstrap calls `RoleResource::registerTenancyModelGlobalScope()` / `observeTenancyModelCreation()` for every resource. Without an explicit exemption, Filament resolves tenant ownership via `Role::store()`, but **Spatie’s `Permission` `Role` model has no such relationship**. That mismatch surfaces as:

`LogicException: ... does not have a relationship named [store]`

Shield roles are intentionally global—this resource must not participate in tenant ownership scoping.

## Fix

For `App\Filament\Resources\Shield\Roles\RoleResource`:

- Keep `$isScopedToTenant = false` and expose it via `isScopedToTenant()`.
- Override `registerTenancyModelGlobalScope()` and `observeTenancyModelCreation()` as **no-ops** so panel boot cannot register tenant scopes or tenant creation hooks against the Role model.

## How to verify

1. Fast check (no DB):  
   `./vendor/bin/pest tests/Unit/RoleResourceTenancyTest.php`
2. With a configured test DB per `phpunit.xml`:  
   `php artisan test --compact tests/Feature/Filament/RoleResourceTenantScopeRegistrationTest.php`
3. Manual: Sign in to the tenant-scoped Filament panel, switch to any store tenant, visit **Roles** — list and queries load without `LogicException` referencing `Role` and relationship `store`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afd8f2a2-f569-4c40-9d1d-0a1920a8addc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afd8f2a2-f569-4c40-9d1d-0a1920a8addc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

