### PR TITLE
fix(pos): Stripe minimum charge validation for terminal PaymentIntent (closes Nightwatch nw-ref-37)

### DIFF
--- a/app/Http/Controllers/Stores/StoreTerminalPaymentIntentController.php
+++ b/app/Http/Controllers/Stores/StoreTerminalPaymentIntentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Stores;
 
 use App\Models\Store;
+use App\Support\StripeMinimumChargeMinorUnits;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -16,10 +17,10 @@ class StoreTerminalPaymentIntentController extends Controller
         // TODO: Authorize the caller (e.g. Sanctum / JWT / your own guard)
 
         $validated = $request->validate([
-            'amount'      => ['required', 'integer', 'min:1'],  // in minor units
-            'currency'    => ['nullable', 'string', 'size:3'],
+            'amount' => ['required', 'integer', 'min:1'],  // in minor units
+            'currency' => ['nullable', 'string', 'size:3'],
             'description' => ['nullable', 'string', 'max:255'],
-            'metadata'    => ['nullable', 'array'],
+            'metadata' => ['nullable', 'array'],
         ]);
 
         if (! $store->hasStripeAccount()) {
@@ -41,14 +42,29 @@ class StoreTerminalPaymentIntentController extends Controller
             ?? ($store->currency ?? config('cashier.currency', 'usd'))
         );
 
+        $stripeMinimumMinor = StripeMinimumChargeMinorUnits::forCurrency($currency);
+        if ($stripeMinimumMinor !== null && $validated['amount'] < $stripeMinimumMinor) {
+            $minimumLabel = StripeMinimumChargeMinorUnits::describeMinimumCharge($currency)
+                ?? (string) $stripeMinimumMinor;
+
+            return response()->json([
+                'message' => 'The payment amount is below the minimum Stripe allows for this currency.',
+                'errors' => [
+                    'amount' => [
+                        "The payment amount must be at least {$minimumLabel} for terminal card payments.",
+                    ],
+                ],
+            ], 422);
+        }
+
         $stripe = new StripeClient($secret);
 
         try {
             $params = [
-                'amount'               => $validated['amount'],
-                'currency'             => $currency,
+                'amount' => $validated['amount'],
+                'currency' => $currency,
                 'payment_method_types' => ['card_present'],
-                'capture_method'       => 'automatic', // Terminal flow: create → collect → capture
+                'capture_method' => 'automatic', // Terminal flow: create → collect → capture
             ];
 
             if (! empty($validated['description'])) {
@@ -71,7 +87,7 @@ class StoreTerminalPaymentIntentController extends Controller
 
             return response()->json([
                 'message' => 'Failed to create payment intent.',
-                'error'   => $e->getMessage(),
+                'error' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Support/StripeMinimumChargeMinorUnits.php
+++ b/app/Support/StripeMinimumChargeMinorUnits.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Stripe minimum payment amounts per presentment currency, in minor units as required by the API.
+ *
+ * @see https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+ */
+final class StripeMinimumChargeMinorUnits
+{
+    /**
+     * @var array<string, int> Lowercase ISO 4217 => minimum charge in Stripe API minor units
+     */
+    private const MIN_MINOR_BY_CURRENCY = [
+        'aed' => 200,
+        'ars' => 50,
+        'aud' => 50,
+        'brl' => 50,
+        'cad' => 50,
+        'chf' => 50,
+        'cop' => 50,
+        'czk' => 1500,
+        'dkk' => 250,
+        'eur' => 50,
+        'gbp' => 30,
+        'hkd' => 400,
+        'huf' => 17500,
+        'ils' => 50,
+        'inr' => 50,
+        'jpy' => 50,
+        'krw' => 50,
+        'mxn' => 1000,
+        'myr' => 200,
+        'nok' => 300,
+        'nzd' => 50,
+        'php' => 50,
+        'pln' => 200,
+        'ron' => 200,
+        'rub' => 50,
+        'sek' => 300,
+        'sgd' => 50,
+        'thb' => 1000,
+        'usd' => 50,
+        'zar' => 50,
+    ];
+
+    /**
+     * Returns null when Stripe does not document a minimum in {@see self::MIN_MINOR_BY_CURRENCY};
+     * the API will enforce its rules for that currency.
+     */
+    public static function forCurrency(string $currency): ?int
+    {
+        $code = strtolower($currency);
+
+        return self::MIN_MINOR_BY_CURRENCY[$code] ?? null;
+    }
+
+    /**
+     * User-facing phrase for validation errors (e.g. "3.00 kr (NOK)").
+     */
+    public static function describeMinimumCharge(string $currency): ?string
+    {
+        $minor = self::forCurrency($currency);
+        if ($minor === null) {
+            return null;
+        }
+
+        $codeUpper = strtoupper($currency);
+
+        return match ($codeUpper) {
+            'JPY', 'KRW' => number_format($minor, 0, '.', '').' '.$codeUpper,
+            default => number_format($minor / 100, 2, '.', '').' '.$codeUpper,
+        };
+    }
+}

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Feature/StoreTerminalPaymentIntentMinimumAmountTest.php
+++ b/tests/Feature/StoreTerminalPaymentIntentMinimumAmountTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Stores\StoreTerminalPaymentIntentController;
+use App\Models\Store;
+use Illuminate\Http\Request;
+
+it('returns 422 when terminal payment intent amount is below Stripe minimum for NOK', function (): void {
+    config(['cashier.secret' => 'sk_test_placeholder']);
+
+    $store = new class extends Store
+    {
+        public function hasStripeAccount(): bool
+        {
+            return true;
+        }
+    };
+
+    $store->forceFill(['stripe_account_id' => 'acct_test_minimum']);
+
+    $request = Request::create('/ignored', 'POST', [
+        'amount' => 299,
+        'currency' => 'nok',
+    ]);
+
+    $response = app(StoreTerminalPaymentIntentController::class)($store, $request);
+
+    expect($response->getStatusCode())->toBe(422);
+    $payload = $response->getData(true);
+    expect($payload['message'])->toBe('The payment amount is below the minimum Stripe allows for this currency.');
+    expect($payload['errors']['amount'][0])
+        ->toBe('The payment amount must be at least 3.00 NOK for terminal card payments.');
+});

--- a/tests/Unit/Support/StripeMinimumChargeMinorUnitsTest.php
+++ b/tests/Unit/Support/StripeMinimumChargeMinorUnitsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\StripeMinimumChargeMinorUnits;
+
+it('maps NOK to Stripe documented minimum minor units', function (): void {
+    expect(StripeMinimumChargeMinorUnits::forCurrency('nok'))->toBe(300)
+        ->and(StripeMinimumChargeMinorUnits::forCurrency('NOK'))->toBe(300);
+});
+
+it('describes two-decimal minimums clearly', function (): void {
+    expect(StripeMinimumChargeMinorUnits::describeMinimumCharge('nok'))->toBe('3.00 NOK');
+});
+
+it('uses API minor amounts for zero-decimal currencies', function (): void {
+    expect(StripeMinimumChargeMinorUnits::forCurrency('jpy'))->toBe(50)
+        ->and(StripeMinimumChargeMinorUnits::describeMinimumCharge('jpy'))->toBe('50 JPY');
+});
+
+it('returns null for undocumented currencies so Stripe continues to enforce', function (): void {
+    expect(StripeMinimumChargeMinorUnits::forCurrency('xxx'))
+        ->toBeNull()
+        ->and(StripeMinimumChargeMinorUnits::describeMinimumCharge('xxx'))
+        ->toBeNull();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks https://github.com/janiator/filament-pos-stripe/issues/95

**Nightwatch:** nw-ref-37 (Nightwatch reference #37)

## Cause

`POST /api/stores/{store}/terminal/payment-intents` accepted any positive integer `amount` (`min:1`). For NOK and other currencies, Stripe enforces higher minimum charges (documented minimum for NOK is **3.00 kr** → **300 øre** in minor units). Requesting smaller amounts triggered `Stripe\Exception\InvalidRequestException` (“Amount must be at least kr3.00 nok”) only after the Stripe API call.

## Fix

- Resolve effective presentment currency the same way as before (request → store → cashier default).
- Look up Stripe’s documented minimum for that ISO currency in **`App\Support\StripeMinimumChargeMinorUnits`** ([Stripe docs — minimum charge amounts](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts)).
- When the amount is below that minimum **before** `paymentIntents->create`, respond with **HTTP 422**, `message`, and `errors.amount` with an explicit explanation (instead of propagating Stripe’s exception).

## How to verify

```bash
APP_KEY='<testing-key-if-required>' php artisan test --compact \
  tests/Feature/StoreTerminalPaymentIntentMinimumAmountTest.php \
  tests/Unit/Support/StripeMinimumChargeMinorUnitsTest.php
```

The feature test exercises `StoreTerminalPaymentIntentController` with an amount below the NOK minimum and asserts JSON `422` and the structured error payload (no Stripe network call).

## Additional note

`packages/filament-webflow` overrides `Filament\Pages\Page::getUrl` with a signature Filament v4 widened (`$shouldGuessMissingParameters`, `$configuration`). Without aligning those overrides, the application fatals during class load when running tests or bootstrapping Filament panels. Those two signatures are forwarded to `parent::getUrl` unchanged in behavior besides compatibility.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1b2604-04b9-41c4-acb3-694e14e3eb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1b2604-04b9-41c4-acb3-694e14e3eb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

