### PR TITLE
Fix Stripe: set product default_price before archiving old price (Nightwatch nw-ref-16)

### DIFF
--- a/app/Actions/ConnectedPrices/SyncProductPrice.php
+++ b/app/Actions/ConnectedPrices/SyncProductPrice.php
@@ -115,6 +115,11 @@ class SyncProductPrice
         $product->default_price = $newPriceId;
         $product->saveQuietly();
 
+        // Stripe rejects archiving or deleting a price that is still the product's default_price.
+        // saveQuietly() skips listeners, so the connected Stripe Product may still reference the
+        // old default until we update it explicitly before touching old prices.
+        $this->updateStripeProductDefaultPrice($product, $newPriceId);
+
         // Handle old prices - archive if used, delete if not
         foreach ($existingPrices as $oldPrice) {
             if ($this->priceHasBeenUsed($oldPrice)) {
@@ -213,6 +218,40 @@ class SyncProductPrice
         }
 
         return false;
+    }
+
+    /**
+     * Point the Stripe Product at the new default price before archiving prior prices.
+     */
+    protected function updateStripeProductDefaultPrice(ConnectedProduct $product, string $defaultPriceId): void
+    {
+        try {
+            $secret = config('cashier.secret') ?? config('services.stripe.secret');
+            if (! $secret) {
+                return;
+            }
+
+            $stripe = $this->makeStripeClient($secret);
+
+            $stripe->products->update(
+                $product->stripe_product_id,
+                ['default_price' => $defaultPriceId],
+                ['stripe_account' => $product->stripe_account_id]
+            );
+        } catch (Throwable $e) {
+            Log::error('Failed to update Stripe product default price before archiving old prices', [
+                'product_id' => $product->id,
+                'stripe_product_id' => $product->stripe_product_id,
+                'default_price' => $defaultPriceId,
+                'error' => $e->getMessage(),
+            ]);
+            report($e);
+        }
+    }
+
+    protected function makeStripeClient(string $secret): StripeClient
+    {
+        return new StripeClient($secret);
     }
 
     /**

--- a/tests/Unit/Actions/ConnectedPrices/SyncProductPriceStripeDefaultPriceTest.php
+++ b/tests/Unit/Actions/ConnectedPrices/SyncProductPriceStripeDefaultPriceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\ConnectedPrices\SyncProductPrice;
+use App\Models\ConnectedProduct;
+use Stripe\StripeClient;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+afterEach(function () {
+    Mockery::close();
+});
+
+/**
+ * Stripe rejects archiving a price that is still the product's default_price.
+ * updateStripeProductDefaultPrice() must call the Stripe Products API so the product
+ * references the new price before any price is archived (see SyncProductPrice::__invoke).
+ */
+it('updates the Stripe product default price via the Products API', function () {
+    config(['cashier.secret' => 'sk_test_fake']);
+
+    $product = new ConnectedProduct([
+        'stripe_product_id' => 'prod_unit_test',
+        'stripe_account_id' => 'acct_unit_test',
+    ]);
+    $product->id = 42;
+
+    $mockProducts = Mockery::mock();
+    $mockProducts->shouldReceive('update')
+        ->once()
+        ->with(
+            'prod_unit_test',
+            ['default_price' => 'price_new'],
+            ['stripe_account' => 'acct_unit_test'],
+        )
+        ->andReturn((object) ['id' => 'prod_unit_test']);
+
+    $mockStripe = Mockery::mock(StripeClient::class);
+    $mockStripe->products = $mockProducts;
+
+    $action = new class($mockStripe) extends SyncProductPrice
+    {
+        public function __construct(
+            private readonly StripeClient $stripeClient,
+        ) {}
+
+        protected function makeStripeClient(string $secret): StripeClient
+        {
+            return $this->stripeClient;
+        }
+    };
+
+    $method = new ReflectionMethod(SyncProductPrice::class, 'updateStripeProductDefaultPrice');
+    $method->setAccessible(true);
+    $method->invoke($action, $product, 'price_new');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

- Closes / tracks https://github.com/janiator/filament-pos-stripe/issues/97
- **Nightwatch**: `nw-ref-16` — exception: Stripe cannot archive the default price of a product (stack: `SyncProductPrice::archivePrice` → `SyncProductPrice::deletePrice`)

## Cause

After creating a new Stripe price, the action set `default_price` on `ConnectedProduct` and called `saveQuietly()`. That skips model listeners, and nothing updated the **Stripe Product**’s `default_price` before the code tried to archive or delete older `prices`. Stripe returns an error when you deactivate or delete a price that is still the product’s default.

## Fix

- After persisting the new default price id locally, call Stripe **`products->update`** on the connected account with `default_price` set to the new price id **before** archiving or deleting any existing prices in the foreach loop.
- Added `updateStripeProductDefaultPrice()` plus a small `makeStripeClient()` hook so the Stripe call can be covered by a unit test without brittle global mocks.

## How to verify

- Run: `php artisan test --compact tests/Unit/Actions/ConnectedPrices/SyncProductPriceStripeDefaultPriceTest.php`
- In production, changing a product’s price should create/use the new price, move the Stripe product default to that price, then archive old used prices without errors in Nightwatch.

EOF
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ebeaf6a-034d-4028-9d80-55f3b2419f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ebeaf6a-034d-4028-9d80-55f3b2419f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

