### PR TITLE
Fix pos_devices store + device_name race on idempotent register (Nightwatch nw-ref-25)

### DIFF
--- a/app/Http/Controllers/Api/PosDevicesController.php
+++ b/app/Http/Controllers/Api/PosDevicesController.php
@@ -110,36 +110,18 @@ class PosDevicesController extends BaseApiController
         $validated['auto_print_receipt'] = $validated['auto_print_receipt'] ?? true;
 
         if ($device) {
-            // On update, only refresh device-info and heartbeat fields so we don't overwrite
-            // admin-configured values in Filament (booking_enabled, auto_print_receipt, etc.).
-            $updatePayload = [
-                'device_identifier' => $validated['device_identifier'],
-                'platform' => $validated['platform'],
-                'device_model' => $validated['device_model'] ?? null,
-                'device_brand' => $validated['device_brand'] ?? null,
-                'device_manufacturer' => $validated['device_manufacturer'] ?? null,
-                'device_product' => $validated['device_product'] ?? null,
-                'device_hardware' => $validated['device_hardware'] ?? null,
-                'machine_identifier' => $validated['machine_identifier'] ?? null,
-                'system_name' => $validated['system_name'] ?? null,
-                'system_version' => $validated['system_version'] ?? null,
-                'vendor_identifier' => $validated['vendor_identifier'] ?? null,
-                'android_id' => $validated['android_id'] ?? null,
-                'serial_number' => $validated['serial_number'] ?? null,
-                'device_metadata' => $validated['device_metadata'] ?? null,
-                'device_status' => $validated['device_status'],
-                'last_seen_at' => $validated['last_seen_at'],
-            ];
-            $device->update($updatePayload);
+            $this->syncIdempotentRegisterOntoDevice($device, $validated);
 
-            return response()->json([
-                'message' => 'POS device updated successfully',
-                'device' => $this->formatDeviceResponse($device->load(['terminalLocation.terminalReaders', 'lastConnectedTerminalLocation', 'lastConnectedTerminalReader'])),
-                'is_new_device' => false,
-            ], 200);
+            return $this->idempotentRegisterResponse($device, false);
         }
 
-        $device = PosDevice::create($validated);
+        [$device, $insertedNewRow] = PosDevice::createOrFetchForIdempotentRegister($validated, $store->id, $deviceName);
+
+        if (! $insertedNewRow) {
+            $this->syncIdempotentRegisterOntoDevice($device, $validated);
+
+            return $this->idempotentRegisterResponse($device, false);
+        }
 
         if ($store->default_terminal_location_id) {
             $defaultTerminalLocation = TerminalLocation::where('id', $store->default_terminal_location_id)
@@ -151,11 +133,44 @@ class PosDevicesController extends BaseApiController
             }
         }
 
+        return $this->idempotentRegisterResponse($device, true);
+    }
+
+    /**
+     * On idempotent register, only refresh device-info and heartbeat fields so we don't overwrite
+     * admin-configured values in Filament (booking_enabled, auto_print_receipt, etc.).
+     */
+    private function syncIdempotentRegisterOntoDevice(PosDevice $device, array $validated): void
+    {
+        $device->update([
+            'device_identifier' => $validated['device_identifier'],
+            'platform' => $validated['platform'],
+            'device_model' => $validated['device_model'] ?? null,
+            'device_brand' => $validated['device_brand'] ?? null,
+            'device_manufacturer' => $validated['device_manufacturer'] ?? null,
+            'device_product' => $validated['device_product'] ?? null,
+            'device_hardware' => $validated['device_hardware'] ?? null,
+            'machine_identifier' => $validated['machine_identifier'] ?? null,
+            'system_name' => $validated['system_name'] ?? null,
+            'system_version' => $validated['system_version'] ?? null,
+            'vendor_identifier' => $validated['vendor_identifier'] ?? null,
+            'android_id' => $validated['android_id'] ?? null,
+            'serial_number' => $validated['serial_number'] ?? null,
+            'device_metadata' => $validated['device_metadata'] ?? null,
+            'device_status' => $validated['device_status'],
+            'last_seen_at' => $validated['last_seen_at'],
+        ]);
+    }
+
+    private function idempotentRegisterResponse(PosDevice $device, bool $isNewDevice): JsonResponse
+    {
+        $device->load(['terminalLocation.terminalReaders', 'lastConnectedTerminalLocation', 'lastConnectedTerminalReader']);
+
         return response()->json([
-            'message' => 'POS device registered successfully',
-            'device' => $this->formatDeviceResponse($device->load(['terminalLocation.terminalReaders', 'lastConnectedTerminalLocation', 'lastConnectedTerminalReader'])),
-            'is_new_device' => true,
-        ], 201);
+            'message' => $isNewDevice ? 'POS device registered successfully' : 'POS device updated successfully',
+            'device' => $this->formatDeviceResponse($device),
+            'is_new_device' => $isNewDevice,
+        ], $isNewDevice ? 201 : 200);
     }
 
     /**

--- a/app/Models/PosDevice.php
+++ b/app/Models/PosDevice.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\UniqueConstraintViolationException;
 
 class PosDevice extends Model
 {
@@ -50,6 +51,29 @@ class PosDevice extends Model
         'booking_enabled' => 'boolean',
         'auto_print_receipt' => 'boolean',
     ];
+
+    /**
+     * Insert for idempotent /register; recovers when concurrent requests race on store_id + device_name.
+     *
+     * @return array{0: PosDevice, 1: bool} The device model, and true when a new row was inserted.
+     */
+    public static function createOrFetchForIdempotentRegister(array $validated, int $storeId, string $deviceName): array
+    {
+        try {
+            return [static::query()->create($validated), true];
+        } catch (UniqueConstraintViolationException $exception) {
+            $device = static::query()
+                ->where('store_id', $storeId)
+                ->where('device_name', $deviceName)
+                ->first();
+
+            if ($device === null) {
+                throw $exception;
+            }
+
+            return [$device, false];
+        }
+    }
 
     public function store(): BelongsTo
     {

--- a/tests/Feature/PosDeviceIdempotentRegisterRaceTest.php
+++ b/tests/Feature/PosDeviceIdempotentRegisterRaceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\PosDevice;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns existing device after unique violation on store_id and device_name', function (): void {
+    $store = Store::factory()->create();
+    $existing = PosDevice::factory()->create([
+        'store_id' => $store->id,
+        'device_name' => 'Register Race Tablet',
+        'device_identifier' => 'concurrent-a',
+        'platform' => 'android',
+    ]);
+
+    $validated = [
+        'store_id' => $store->id,
+        'device_identifier' => 'concurrent-b',
+        'device_name' => 'Register Race Tablet',
+        'platform' => 'android',
+        'device_model' => null,
+        'device_brand' => null,
+        'device_manufacturer' => null,
+        'device_product' => null,
+        'device_hardware' => null,
+        'machine_identifier' => null,
+        'system_name' => null,
+        'system_version' => null,
+        'vendor_identifier' => null,
+        'android_id' => null,
+        'serial_number' => null,
+        'device_status' => 'active',
+        'last_seen_at' => now(),
+        'device_metadata' => null,
+        'cash_drawer_enabled' => true,
+        'has_integrated_drawer' => false,
+        'booking_enabled' => false,
+        'auto_print_receipt' => true,
+    ];
+
+    [$device, $inserted] = PosDevice::createOrFetchForIdempotentRegister(
+        $validated,
+        $store->id,
+        'Register Race Tablet',
+    );
+
+    expect($inserted)->toBeFalse();
+    expect($device->is($existing))->toBeTrue();
+    expect(PosDevice::query()->where('store_id', $store->id)->count())->toBe(1);
+});
+
+it('inserts a new row when no conflicting store and device_name exists', function (): void {
+    $store = Store::factory()->create();
+
+    $validated = [
+        'store_id' => $store->id,
+        'device_identifier' => 'new-android-id',
+        'device_name' => 'Fresh Tablet',
+        'platform' => 'android',
+        'device_model' => null,
+        'device_brand' => null,
+        'device_manufacturer' => null,
+        'device_product' => null,
+        'device_hardware' => null,
+        'machine_identifier' => null,
+        'system_name' => null,
+        'system_version' => null,
+        'vendor_identifier' => null,
+        'android_id' => null,
+        'serial_number' => null,
+        'device_status' => 'active',
+        'last_seen_at' => now(),
+        'device_metadata' => null,
+        'cash_drawer_enabled' => true,
+        'has_integrated_drawer' => false,
+        'booking_enabled' => false,
+        'auto_print_receipt' => true,
+    ];
+
+    [$device, $inserted] = PosDevice::createOrFetchForIdempotentRegister(
+        $validated,
+        $store->id,
+        'Fresh Tablet',
+    );
+
+    expect($inserted)->toBeTrue();
+    expect($device->exists)->toBeTrue();
+    expect(PosDevice::query()->where('store_id', $store->id)->count())->toBe(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Links

- GitHub: https://github.com/janiator/filament-pos-stripe/issues/99
- Nightwatch: **nw-ref-25** (ref #25 in Nightwatch)

## Cause

`POST /api/pos-devices/register` looked up a device with `store_id` + `device_name`, then called `PosDevice::create()` when none existed. Two concurrent requests (typical on Android startup) could both observe “no row” and both insert, so the second hit the database unique index `pos_devices_store_device_name_unique` and raised `UniqueConstraintViolationException`.

## Fix

- `PosDevice::createOrFetchForIdempotentRegister()` wraps `create` in a `try`/`catch` for `UniqueConstraintViolationException`, then reloads the row by `store_id` + `device_name` (or rethrows if no row—unexpected).
- `PosDevicesController::register()` uses that helper; when the insert was not the winner, it runs the same client-field sync as the normal “already exists” path and returns **200** with `is_new_device: false`, matching idempotent behavior.

## How to verify

1. Run tests (requires configured test DB per `phpunit.xml`, e.g. PostgreSQL `pos_stripe_test`):

   `php artisan test --compact tests/Feature/PosDeviceIdempotentRegisterRaceTest.php tests/Feature/PosDeviceDefaultTerminalLocationTest.php`

2. The new file `PosDeviceIdempotentRegisterRaceTest` asserts that when a row already exists for the same store + `device_name`, a second `create`-path call returns the existing device (`inserted === false`) and keeps a single row.

3. **Production-style check:** fire two parallel `POST /api/pos-devices/register` calls with the same `device_name` and store: both should succeed (one **201** `is_new_device: true`, one **200** `is_new_device: false`, or both **200** if the row already existed), with no **500** / unique violation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56e12fd0-5187-4795-94a7-86ba7b483229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56e12fd0-5187-4795-94a7-86ba7b483229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

