### PR TITLE
fix(api): idempotent POS device register (Nightwatch #24 / #101)

### DIFF
--- a/app/Http/Controllers/Api/PosDevicesController.php
+++ b/app/Http/Controllers/Api/PosDevicesController.php
@@ -5,7 +5,12 @@ namespace App\Http\Controllers\Api;
 use App\Enums\AddonType;
 use App\Models\Addon;
 use App\Models\PosDevice;
+use App\Models\PosEvent;
+use App\Models\PosSession;
+use App\Models\ReceiptPrinter;
 use App\Models\TerminalLocation;
+use App\Models\TerminalReader;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -82,6 +87,8 @@ class PosDevicesController extends BaseApiController
             'is_physical_device' => 'nullable|boolean',
         ]);
 
+        $validated['device_name'] = trim($validated['device_name']);
+
         $deviceName = $validated['device_name'];
         $device = PosDevice::where('store_id', $store->id)
             ->where('device_name', $deviceName)
@@ -110,27 +117,7 @@ class PosDevicesController extends BaseApiController
         $validated['auto_print_receipt'] = $validated['auto_print_receipt'] ?? true;
 
         if ($device) {
-            // On update, only refresh device-info and heartbeat fields so we don't overwrite
-            // admin-configured values in Filament (booking_enabled, auto_print_receipt, etc.).
-            $updatePayload = [
-                'device_identifier' => $validated['device_identifier'],
-                'platform' => $validated['platform'],
-                'device_model' => $validated['device_model'] ?? null,
-                'device_brand' => $validated['device_brand'] ?? null,
-                'device_manufacturer' => $validated['device_manufacturer'] ?? null,
-                'device_product' => $validated['device_product'] ?? null,
-                'device_hardware' => $validated['device_hardware'] ?? null,
-                'machine_identifier' => $validated['machine_identifier'] ?? null,
-                'system_name' => $validated['system_name'] ?? null,
-                'system_version' => $validated['system_version'] ?? null,
-                'vendor_identifier' => $validated['vendor_identifier'] ?? null,
-                'android_id' => $validated['android_id'] ?? null,
-                'serial_number' => $validated['serial_number'] ?? null,
-                'device_metadata' => $validated['device_metadata'] ?? null,
-                'device_status' => $validated['device_status'],
-                'last_seen_at' => $validated['last_seen_at'],
-            ];
-            $device->update($updatePayload);
+            $device->update($this->registerDeviceUpdatePayload($validated));
 
             return response()->json([
                 'message' => 'POS device updated successfully',
@@ -139,7 +126,21 @@ class PosDevicesController extends BaseApiController
             ], 200);
         }
 
-        $device = PosDevice::create($validated);
+        try {
+            $device = PosDevice::create($validated);
+        } catch (UniqueConstraintViolationException) {
+            // Concurrent register with the same device_name: the other request inserted first.
+            $device = PosDevice::where('store_id', $store->id)
+                ->where('device_name', $deviceName)
+                ->firstOrFail();
+            $device->update($this->registerDeviceUpdatePayload($validated));
+
+            return response()->json([
+                'message' => 'POS device updated successfully',
+                'device' => $this->formatDeviceResponse($device->load(['terminalLocation.terminalReaders', 'lastConnectedTerminalLocation', 'lastConnectedTerminalReader'])),
+                'is_new_device' => false,
+            ], 200);
+        }
 
         if ($store->default_terminal_location_id) {
             $defaultTerminalLocation = TerminalLocation::where('id', $store->default_terminal_location_id)
@@ -311,7 +312,7 @@ class PosDevicesController extends BaseApiController
 
         // Validate that the printer belongs to the same store
         if (isset($validated['default_printer_id'])) {
-            $printer = \App\Models\ReceiptPrinter::where('id', $validated['default_printer_id'])
+            $printer = ReceiptPrinter::where('id', $validated['default_printer_id'])
                 ->where('store_id', $store->id)
                 ->first();
 
@@ -324,7 +325,7 @@ class PosDevicesController extends BaseApiController
 
         // Validate that last-connected terminal location and reader belong to this store
         if (array_key_exists('last_connected_terminal_location_id', $validated) && $validated['last_connected_terminal_location_id']) {
-            $loc = \App\Models\TerminalLocation::where('id', $validated['last_connected_terminal_location_id'])
+            $loc = TerminalLocation::where('id', $validated['last_connected_terminal_location_id'])
                 ->where('store_id', $store->id)
                 ->first();
             if (! $loc) {
@@ -334,7 +335,7 @@ class PosDevicesController extends BaseApiController
             }
         }
         if (array_key_exists('terminal_location_id', $validated) && $validated['terminal_location_id']) {
-            $loc = \App\Models\TerminalLocation::where('id', $validated['terminal_location_id'])
+            $loc = TerminalLocation::where('id', $validated['terminal_location_id'])
                 ->where('store_id', $store->id)
                 ->first();
             if (! $loc) {
@@ -344,7 +345,7 @@ class PosDevicesController extends BaseApiController
             }
         }
         if (array_key_exists('last_connected_terminal_reader_id', $validated) && $validated['last_connected_terminal_reader_id']) {
-            $reader = \App\Models\TerminalReader::where('id', $validated['last_connected_terminal_reader_id'])
+            $reader = TerminalReader::where('id', $validated['last_connected_terminal_reader_id'])
                 ->where('store_id', $store->id)
                 ->first();
             if (! $reader) {
@@ -406,8 +407,8 @@ class PosDevicesController extends BaseApiController
         // to avoid creating duplicate events if multiple heartbeats arrive quickly
         $recentStartEvent = null;
         if ($wasInactive) {
-            $recentStartEvent = \App\Models\PosEvent::where('pos_device_id', $device->id)
-                ->where('event_code', \App\Models\PosEvent::EVENT_APPLICATION_START)
+            $recentStartEvent = PosEvent::where('pos_device_id', $device->id)
+                ->where('event_code', PosEvent::EVENT_APPLICATION_START)
                 ->where('occurred_at', '>=', now()->subSeconds(30))
                 ->first();
         }
@@ -423,7 +424,7 @@ class PosDevicesController extends BaseApiController
         // Create start event if device was inactive and no recent start event exists
         if ($wasInactive && ! $recentStartEvent) {
             // Get current session if exists
-            $currentSession = \App\Models\PosSession::forStore($store->id)
+            $currentSession = PosSession::forStore($store->id)
                 ->where('pos_device_id', $device->id)
                 ->where('status', 'open')
                 ->first();
@@ -437,12 +438,12 @@ class PosDevicesController extends BaseApiController
                 : null;
 
             // Log application start event (13001)
-            $event = \App\Models\PosEvent::create([
+            $event = PosEvent::create([
                 'store_id' => $store->id,
                 'pos_device_id' => $device->id,
                 'pos_session_id' => $currentSession?->id,
                 'user_id' => $userId,
-                'event_code' => \App\Models\PosEvent::EVENT_APPLICATION_START,
+                'event_code' => PosEvent::EVENT_APPLICATION_START,
                 'event_type' => 'application',
                 'description' => "POS application resumed on device {$device->device_name} after inactivity",
                 'event_data' => [
@@ -494,14 +495,14 @@ class PosDevicesController extends BaseApiController
             ->firstOrFail();
 
         // Get current session if exists
-        $currentSession = \App\Models\PosSession::forStore($store->id)
+        $currentSession = PosSession::forStore($store->id)
             ->where('pos_device_id', $device->id)
             ->where('status', 'open')
             ->first();
 
         // Check for recent start event to prevent duplicates (within last 30 seconds)
-        $recentStartEvent = \App\Models\PosEvent::where('pos_device_id', $device->id)
-            ->where('event_code', \App\Models\PosEvent::EVENT_APPLICATION_START)
+        $recentStartEvent = PosEvent::where('pos_device_id', $device->id)
+            ->where('event_code', PosEvent::EVENT_APPLICATION_START)
             ->where('occurred_at', '>=', now()->subSeconds(30))
             ->first();
 
@@ -528,12 +529,12 @@ class PosDevicesController extends BaseApiController
         $userId = $request->user()?->id;
 
         // Log application start event (13001)
-        $event = \App\Models\PosEvent::create([
+        $event = PosEvent::create([
             'store_id' => $store->id,
             'pos_device_id' => $device->id,
             'pos_session_id' => $currentSession?->id,
             'user_id' => $userId,
-            'event_code' => \App\Models\PosEvent::EVENT_APPLICATION_START,
+            'event_code' => PosEvent::EVENT_APPLICATION_START,
             'event_type' => 'application',
             'description' => "POS application started on device {$device->device_name}",
             'event_data' => [
@@ -576,7 +577,7 @@ class PosDevicesController extends BaseApiController
             ->firstOrFail();
 
         // Get current session if exists
-        $currentSession = \App\Models\PosSession::forStore($store->id)
+        $currentSession = PosSession::forStore($store->id)
             ->where('pos_device_id', $device->id)
             ->where('status', 'open')
             ->first();
@@ -591,12 +592,12 @@ class PosDevicesController extends BaseApiController
         ]);
 
         // Log application shutdown event (13002)
-        $event = \App\Models\PosEvent::create([
+        $event = PosEvent::create([
             'store_id' => $store->id,
             'pos_device_id' => $device->id,
             'pos_session_id' => $currentSession?->id,
             'user_id' => $userId,
-            'event_code' => \App\Models\PosEvent::EVENT_APPLICATION_SHUTDOWN,
+            'event_code' => PosEvent::EVENT_APPLICATION_SHUTDOWN,
             'event_type' => 'application',
             'description' => "POS application shut down on device {$device->device_name}",
             'event_data' => [
@@ -663,11 +664,11 @@ class PosDevicesController extends BaseApiController
         // Get current session if not provided
         $session = null;
         if (isset($validated['pos_session_id'])) {
-            $session = \App\Models\PosSession::where('id', $validated['pos_session_id'])
+            $session = PosSession::where('id', $validated['pos_session_id'])
                 ->where('store_id', $store->id)
                 ->first();
         } else {
-            $session = \App\Models\PosSession::forStore($store->id)
+            $session = PosSession::forStore($store->id)
                 ->where('pos_device_id', $device->id)
                 ->where('status', 'open')
                 ->first();
@@ -682,13 +683,13 @@ class PosDevicesController extends BaseApiController
         }
 
         // Log cash drawer open event (13005)
-        \App\Models\PosEvent::create([
+        PosEvent::create([
             'store_id' => $store->id,
             'pos_device_id' => $device->id,
             'pos_session_id' => $session?->id,
             'user_id' => $request->user()->id,
             'related_charge_id' => $validated['related_charge_id'] ?? null,
-            'event_code' => \App\Models\PosEvent::EVENT_CASH_DRAWER_OPEN,
+            'event_code' => PosEvent::EVENT_CASH_DRAWER_OPEN,
             'event_type' => 'drawer',
             'description' => $isNullinnslag
                 ? 'Cash drawer opened without sale (nullinnslag)'
@@ -742,23 +743,23 @@ class PosDevicesController extends BaseApiController
         // Get current session if not provided
         $session = null;
         if (isset($validated['pos_session_id'])) {
-            $session = \App\Models\PosSession::where('id', $validated['pos_session_id'])
+            $session = PosSession::where('id', $validated['pos_session_id'])
                 ->where('store_id', $store->id)
                 ->first();
         } else {
-            $session = \App\Models\PosSession::forStore($store->id)
+            $session = PosSession::forStore($store->id)
                 ->where('pos_device_id', $device->id)
                 ->where('status', 'open')
                 ->first();
         }
 
         // Log cash drawer close event (13006)
-        \App\Models\PosEvent::create([
+        PosEvent::create([
             'store_id' => $store->id,
             'pos_device_id' => $device->id,
             'pos_session_id' => $session?->id,
             'user_id' => $request->user()->id,
-            'event_code' => \App\Models\PosEvent::EVENT_CASH_DRAWER_CLOSE,
+            'event_code' => PosEvent::EVENT_CASH_DRAWER_CLOSE,
             'event_type' => 'drawer',
             'description' => 'Cash drawer closed',
             'event_data' => [],
@@ -771,8 +772,33 @@ class PosDevicesController extends BaseApiController
     }
 
     /**
-     * Format device response with all information
+     * Fields refreshed from the client on register/update (does not overwrite Filament-only toggles).
+     *
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
      */
+    protected function registerDeviceUpdatePayload(array $validated): array
+    {
+        return [
+            'device_identifier' => $validated['device_identifier'],
+            'platform' => $validated['platform'],
+            'device_model' => $validated['device_model'] ?? null,
+            'device_brand' => $validated['device_brand'] ?? null,
+            'device_manufacturer' => $validated['device_manufacturer'] ?? null,
+            'device_product' => $validated['device_product'] ?? null,
+            'device_hardware' => $validated['device_hardware'] ?? null,
+            'machine_identifier' => $validated['machine_identifier'] ?? null,
+            'system_name' => $validated['system_name'] ?? null,
+            'system_version' => $validated['system_version'] ?? null,
+            'vendor_identifier' => $validated['vendor_identifier'] ?? null,
+            'android_id' => $validated['android_id'] ?? null,
+            'serial_number' => $validated['serial_number'] ?? null,
+            'device_metadata' => $validated['device_metadata'] ?? null,
+            'device_status' => $validated['device_status'],
+            'last_seen_at' => $validated['last_seen_at'],
+        ];
+    }
+
     /**
      * Format last-connected terminal for API response (for auto-reconnect)
      */

--- a/tests/Feature/PosDeviceRegisterConcurrencyTest.php
+++ b/tests/Feature/PosDeviceRegisterConcurrencyTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Models\PosDevice;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('register trims device_name to match an existing device row', function (): void {
+    $user = User::factory()->create();
+    $store = Store::factory()->create();
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+    Sanctum::actingAs($user, ['*']);
+
+    $this->postJson('/api/pos-devices/register', [
+        'device_identifier' => 'vendor-id-trim-test',
+        'device_name' => 'iPad',
+        'platform' => 'ios',
+    ])->assertStatus(201);
+
+    $response = $this->postJson('/api/pos-devices/register', [
+        'device_identifier' => 'vendor-id-trim-test-updated',
+        'device_name' => " \t iPad ",
+        'platform' => 'ios',
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertJsonPath('device.device_name', 'iPad');
+    $response->assertJsonPath('device.device_identifier', 'vendor-id-trim-test-updated');
+    expect(PosDevice::where('store_id', $store->id)->where('device_name', 'iPad')->count())->toBe(1);
+});
+
+it('concurrent register requests for the same device_name do not fail with a unique constraint violation', function (): void {
+    if (! function_exists('pcntl_fork')) {
+        $this->markTestSkipped('pcntl_fork is not available in this environment.');
+    }
+
+    $user = User::factory()->create();
+    $store = Store::factory()->create();
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+    $token = $user->createToken('concurrency-test')->plainTextToken;
+
+    $payload = [
+        'device_identifier' => 'fork-concurrent-'.uniqid(),
+        'device_name' => 'iPad',
+        'platform' => 'ios',
+    ];
+
+    $payloadJson = json_encode($payload, JSON_THROW_ON_ERROR);
+
+    $basePath = dirname(__DIR__, 2);
+    $statusFile = tempnam(sys_get_temp_dir(), 'posregfork');
+    if ($statusFile === false) {
+        $this->fail('Could not create temp file for fork status.');
+    }
+
+    $runRegisterRequest = static function () use ($basePath, $token, $payloadJson): int {
+        /** @var Application $app */
+        $app = require $basePath.'/bootstrap/app.php';
+        $app->make(ConsoleKernel::class)->bootstrap();
+        DB::purge();
+        DB::reconnect();
+
+        $kernel = $app->make(HttpKernel::class);
+        $request = Request::create(
+            '/api/pos-devices/register',
+            'POST',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$token,
+            ],
+            $payloadJson
+        );
+
+        $response = $kernel->handle($request);
+        $kernel->terminate($request, $response);
+
+        return $response->getStatusCode();
+    };
+
+    $pid = pcntl_fork();
+    if ($pid === -1) {
+        @unlink($statusFile);
+        $this->fail('pcntl_fork failed.');
+    }
+
+    if ($pid === 0) {
+        $code = $runRegisterRequest();
+        file_put_contents($statusFile, (string) $code);
+
+        exit(0);
+    }
+
+    $parentCode = $runRegisterRequest();
+    pcntl_waitpid($pid, $status);
+    $childContents = @file_get_contents($statusFile);
+    @unlink($statusFile);
+
+    expect($childContents)->not->toBeFalse('child status file was not written');
+    $childCode = (int) $childContents;
+
+    expect($parentCode)->toBeIn([200, 201]);
+    expect($childCode)->toBeIn([200, 201]);
+    expect(PosDevice::where('store_id', $store->id)->where('device_name', 'iPad')->count())->toBe(1);
+})->group('pcntl');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks [issue #101](https://github.com/janiator/filament-pos-stripe/issues/101). Nightwatch: **nw-ref-24** (`pos_devices_store_device_name_unique`, iPad).

**Cause**  
`/api/pos-devices/register` looked up an existing row by `(store_id, device_name)`, then called `PosDevice::create()` when none was found. Two requests starting at the same time (same store and logical device name, e.g. app cold-start / retries on iPad) could both miss the row and insert, so the second hit the unique index `pos_devices_store_device_name_unique`. Minor name variants (leading/trailing spaces) also failed to match an existing row.

**Fix**  
- Trim `device_name` after validation so lookups match stored values.  
- Wrap create in `try/catch` for `UniqueConstraintViolationException`; on duplicate key, reload by `(store_id, device_name)` and apply the same update payload as a normal re-register (HTTP 200, `is_new_device: false`).  
- Centralize that update field list in `registerDeviceUpdatePayload()`.

**How to verify**  
- Run: `php artisan test --compact tests/Feature/PosDeviceRegisterConcurrencyTest.php tests/Feature/PosDeviceDefaultTerminalLocationTest.php`  
- Exercise: `POST /api/pos-devices/register` twice in parallel with identical `device_name` for the same store; both should succeed (201 + 200 or 200 + 200) and only one `pos_devices` row should exist for that name. The new fork-based test covers the race when `pcntl_fork` is available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73bb659f-99d9-49d9-9b66-59db1edd6d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73bb659f-99d9-49d9-9b66-59db1edd6d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

