### PR TITLE
Fix ConnectedCharge unique violation on Stripe charge webhooks (Nightwatch nw-ref-19)

### DIFF
--- a/app/Actions/Webhooks/HandleChargeWebhook.php
+++ b/app/Actions/Webhooks/HandleChargeWebhook.php
@@ -2,10 +2,12 @@
 
 namespace App\Actions\Webhooks;
 
+use App\Jobs\PushTicketCountsToWebflow;
 use App\Models\ConnectedCharge;
 use App\Models\ConnectedPaymentLink;
 use App\Models\EventTicket;
 use App\Models\Store;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Stripe\Charge;
 use Stripe\StripeClient;
 
@@ -13,6 +15,10 @@ use Stripe\StripeClient;
  * Processes Stripe charge webhooks. Looks up by stripe_payment_intent_id first when
  * present; when found, updates that row and preserves pos_session_id and other POS
  * fields so webhook and POS-created charges are merged without duplicates or lost session.
+ *
+ * Lookups use Stripe global ids only (payment intent, charge id), not
+ * stripe_account_id, so rows created with a null account still merge and we avoid
+ * insert races against connected_charges_stripe_charge_id_unique.
  */
 class HandleChargeWebhook
 {
@@ -77,9 +83,7 @@ class HandleChargeWebhook
 
         // Look up by payment_intent_id first when present: merge into existing row and preserve POS fields
         if ($charge->payment_intent) {
-            $existing = ConnectedCharge::where('stripe_payment_intent_id', $charge->payment_intent)
-                ->where('stripe_account_id', $store->stripe_account_id)
-                ->first();
+            $existing = ConnectedCharge::where('stripe_payment_intent_id', $charge->payment_intent)->first();
 
             if ($existing) {
                 $existing->fill($data);
@@ -100,11 +104,9 @@ class HandleChargeWebhook
             }
         }
 
-        // No row found by payment_intent_id: updateOrCreate by (stripe_charge_id, stripe_account_id)
+        // No row matched by payment_intent: find or create by stripe_charge_id (globally unique).
         if (! $chargeRecord) {
-            $chargeRecord = ConnectedCharge::where('stripe_charge_id', $charge->id)
-                ->where('stripe_account_id', $store->stripe_account_id)
-                ->first();
+            $chargeRecord = ConnectedCharge::where('stripe_charge_id', $charge->id)->first();
 
             $wasCreated = false;
             if ($chargeRecord) {
@@ -117,8 +119,20 @@ class HandleChargeWebhook
                 }
                 $chargeRecord->save();
             } else {
-                $chargeRecord = ConnectedCharge::create($data);
-                $wasCreated = true;
+                try {
+                    $chargeRecord = ConnectedCharge::create($data);
+                    $wasCreated = true;
+                } catch (UniqueConstraintViolationException) {
+                    $chargeRecord = ConnectedCharge::where('stripe_charge_id', $charge->id)->firstOrFail();
+                    $chargeRecord->fill($data);
+                    $chargeRecord->stripe_account_id = $store->stripe_account_id;
+                    foreach (self::PRESERVED_POS_FIELDS as $field) {
+                        if ($chargeRecord->getRawOriginal($field) !== null) {
+                            $chargeRecord->$field = $chargeRecord->getRawOriginal($field);
+                        }
+                    }
+                    $chargeRecord->save();
+                }
             }
 
             \Log::info('Charge webhook processed successfully', [
@@ -184,7 +198,7 @@ class HandleChargeWebhook
                 'quantity' => $quantity,
             ]);
 
-            \App\Jobs\PushTicketCountsToWebflow::dispatch($eventTicket);
+            PushTicketCountsToWebflow::dispatch($eventTicket);
         } catch (\Throwable $e) {
             \Log::warning('Event ticket purchase handling failed', [
                 'charge_id' => $charge->id,

--- a/tests/Feature/WebhookAndObserverPosSessionTest.php
+++ b/tests/Feature/WebhookAndObserverPosSessionTest.php
@@ -10,6 +10,7 @@ use App\Models\PosSession;
 use App\Models\Store;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Stripe\Charge;
+use Stripe\PaymentMethod;
 
 uses(RefreshDatabase::class);
 
@@ -90,6 +91,66 @@ it('merges webhook into existing charge by payment_intent_id and preserves pos_s
     expect(ConnectedCharge::where('stripe_payment_intent_id', $paymentIntentId)->count())->toBe(1);
 });
 
+it('merges charge webhook by payment_intent when existing row has null stripe_account_id', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+    $paymentIntentId = 'pi_'.uniqid();
+    $stripeChargeId = 'ch_'.uniqid();
+
+    ConnectedCharge::factory()->create([
+        'stripe_charge_id' => $stripeChargeId,
+        'stripe_account_id' => null,
+        'stripe_payment_intent_id' => $paymentIntentId,
+        'pos_session_id' => null,
+    ]);
+
+    $stripeCharge = makeStripeChargeForWebhook([
+        'id' => $stripeChargeId,
+        'payment_intent' => $paymentIntentId,
+        'on_behalf_of' => $store->stripe_account_id,
+    ]);
+
+    app(HandleChargeWebhook::class)->handle(
+        $stripeCharge,
+        'charge.succeeded',
+        $store->stripe_account_id
+    );
+
+    expect(ConnectedCharge::where('stripe_payment_intent_id', $paymentIntentId)->count())->toBe(1);
+
+    $row = ConnectedCharge::where('stripe_payment_intent_id', $paymentIntentId)->first();
+    expect($row->stripe_account_id)->toBe($store->stripe_account_id)
+        ->and($row->stripe_charge_id)->toBe($stripeChargeId);
+});
+
+it('updates existing charge by stripe_charge_id when stripe_account_id is null and payment_intent is absent', function () {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
+    $stripeChargeId = 'ch_'.uniqid();
+
+    ConnectedCharge::factory()->create([
+        'stripe_charge_id' => $stripeChargeId,
+        'stripe_account_id' => null,
+        'stripe_payment_intent_id' => null,
+        'pos_session_id' => null,
+    ]);
+
+    $stripeCharge = makeStripeChargeForWebhook([
+        'id' => $stripeChargeId,
+        'payment_intent' => null,
+        'on_behalf_of' => $store->stripe_account_id,
+    ]);
+
+    app(HandleChargeWebhook::class)->handle(
+        $stripeCharge,
+        'charge.updated',
+        $store->stripe_account_id
+    );
+
+    expect(ConnectedCharge::where('stripe_charge_id', $stripeChargeId)->count())->toBe(1);
+
+    $row = ConnectedCharge::where('stripe_charge_id', $stripeChargeId)->first();
+    expect($row->stripe_account_id)->toBe($store->stripe_account_id);
+});
+
 it('does not create POS events when ConnectedCharge has null pos_session_id', function () {
     $store = Store::factory()->create(['stripe_account_id' => 'acct_'.uniqid()]);
 
@@ -168,7 +229,7 @@ it('does not overwrite existing payment method customer with null value', functi
         'card_exp_year' => 2030,
     ]);
 
-    $paymentMethod = \Stripe\PaymentMethod::constructFrom([
+    $paymentMethod = PaymentMethod::constructFrom([
         'id' => $existing->stripe_payment_method_id,
         'customer' => null,
         'type' => 'card',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks https://github.com/janiator/filament-pos-stripe/issues/103 (Laravel Nightwatch **nw-ref-19** / ref #19).

## Cause

`HandleChargeWebhook` matched `connected_charges` rows using **`stripe_payment_intent_id` + `stripe_account_id`** and **`stripe_charge_id` + `stripe_account_id`**. Rows that already had the Stripe payment intent or charge id but **`stripe_account_id` was null** (or otherwise did not match) were not found. The handler then called **`create()`** with a `stripe_charge_id` that was already taken, which violates the partial unique index **`connected_charges_stripe_charge_id_unique`**. The same failure mode can appear under concurrent webhook delivery when two requests both attempt an insert for the same charge id.

## Fix

- Resolve existing rows by Stripe-global identifiers only: **`stripe_payment_intent_id`**, then **`stripe_charge_id`** (no `stripe_account_id` predicate on those lookups). The webhook still sets `stripe_account_id` from the resolved store when saving.
- Wrap **`ConnectedCharge::create()`** in **`try` / `catch (UniqueConstraintViolationException)`**: on duplicate key, load the row by **`stripe_charge_id`** and apply the same merge/update path so retries and races remain idempotent.

## How to verify

```bash
php artisan test --compact tests/Feature/WebhookAndObserverPosSessionTest.php
```

New regression coverage:

- merge by payment intent when the existing row has **null** `stripe_account_id`
- update by `stripe_charge_id` when `stripe_account_id` is null and **`payment_intent` is absent** on the Charge object

(If your app bootstrap or Postgres test DB is misconfigured locally, CI on this PR should still run the same file against the project’s configured test database.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de7bddf7-7fb8-40b8-9902-03b4de3012c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de7bddf7-7fb8-40b8-9902-03b4de3012c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

