### PR TITLE
Nightwatch nw-ref-42: Handle inaccessible Stripe Connect accounts in POS/API

### DIFF
--- a/app/Exceptions/StripeConnectedAccountInaccessible.php
+++ b/app/Exceptions/StripeConnectedAccountInaccessible.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+/**
+ * Raised when Stripe Connect rejects platform access to this store's connected account ID
+ * (for example stale `stripe_account_id`, disconnected Standard account, or wrong Stripe keys/app).
+ */
+final class StripeConnectedAccountInaccessible extends Exception
+{
+    public const USER_MESSAGE = 'Stripe is not reachable for this store\'s linked account on this integration. Disconnect and reconnect Stripe for this store, or verify the Stripe account is still linked to this platform.';
+
+    private function __construct(
+        string $message,
+        private readonly string $validationKey,
+    ) {
+        parent::__construct($message);
+    }
+
+    /**
+     * @param  non-empty-string  $validationKey
+     */
+    public static function generic(string $validationKey = 'stripe_account'): self
+    {
+        return new self(self::USER_MESSAGE, $validationKey);
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function validationErrors(): array
+    {
+        return [
+            $this->validationKey => [$this->getMessage()],
+        ];
+    }
+
+    /**
+     * Exposed only for callers that need structured column keys (FlutterFlow / Laravel validation payloads).
+     */
+    public function fieldKey(): string
+    {
+        return $this->validationKey;
+    }
+}

--- a/app/Http/Controllers/Api/PurchasesController.php
+++ b/app/Http/Controllers/Api/PurchasesController.php
@@ -4,17 +4,24 @@ namespace App\Http\Controllers\Api;
 
 use App\Exceptions\CashDrawerDisabledException;
 use App\Exceptions\InsufficientStockException;
+use App\Exceptions\StripeConnectedAccountInaccessible;
 use App\Http\Requests\Api\CompletePurchasePaymentRequest;
 use App\Http\Requests\Api\ReviseDeferredPurchaseRequest;
 use App\Models\ConnectedCharge;
+use App\Models\ConnectedCustomer;
+use App\Models\ConnectedPaymentIntent;
 use App\Models\ConnectedProduct;
 use App\Models\PaymentMethod;
+use App\Models\PosDevice;
+use App\Models\PosEvent;
 use App\Models\PosSession;
 use App\Models\ProductVariant;
 use App\Services\PurchaseService;
 use Carbon\Carbon;
+use Filament\Facades\Filament;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
@@ -438,7 +445,7 @@ class PurchasesController extends BaseApiController
 
         // If customer_id is provided, verify customer exists and belongs to the store
         if ($customerId !== null) {
-            $customer = \App\Models\ConnectedCustomer::where('stripe_account_id', $store->stripe_account_id)
+            $customer = ConnectedCustomer::where('stripe_account_id', $store->stripe_account_id)
                 ->where('id', (int) $customerId)
                 ->first();
 
@@ -1237,7 +1244,7 @@ class PurchasesController extends BaseApiController
 
         // Try to get store from Filament tenant first, then fall back to user's current store
         try {
-            $store = \Filament\Facades\Filament::getTenant();
+            $store = Filament::getTenant();
         } catch (\Throwable $e) {
             $store = null;
         }
@@ -1272,7 +1279,7 @@ class PurchasesController extends BaseApiController
 
         // When pos_device_id is provided and device has cash drawer disabled, exclude cash methods
         if ($posDeviceId !== null) {
-            $device = \App\Models\PosDevice::where('id', $posDeviceId)
+            $device = PosDevice::where('id', $posDeviceId)
                 ->where('store_id', $store->id)
                 ->first();
             if ($device && $device->cash_drawer_enabled === false) {
@@ -1349,9 +1356,9 @@ class PurchasesController extends BaseApiController
                 // Get store from POS session
                 $posSessionId = $request->input('pos_session_id');
                 if ($posSessionId) {
-                    $posSession = \App\Models\PosSession::find($posSessionId);
+                    $posSession = PosSession::find($posSessionId);
                     if ($posSession && $posSession->store) {
-                        $customer = \App\Models\ConnectedCustomer::where('id', (int) $customerId)
+                        $customer = ConnectedCustomer::where('id', (int) $customerId)
                             ->where('stripe_account_id', $posSession->store->stripe_account_id)
                             ->exists();
 
@@ -1384,7 +1391,7 @@ class PurchasesController extends BaseApiController
 
         // Try to get store from Filament tenant first, then fall back to user's current store
         try {
-            $userStore = \Filament\Facades\Filament::getTenant();
+            $userStore = Filament::getTenant();
         } catch (\Throwable $e) {
             $userStore = null;
         }
@@ -1502,6 +1509,20 @@ class PurchasesController extends BaseApiController
                     ],
                 ],
             ], 201);
+        } catch (StripeConnectedAccountInaccessible $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+                'errors' => $e->validationErrors(),
+            ], 422);
+        } catch (ValidationException $e) {
+            $errors = $e->errors();
+
+            return response()->json([
+                'success' => false,
+                'message' => Arr::flatten($errors)[0] ?? $e->getMessage(),
+                'errors' => $errors,
+            ], 422);
         } catch (CashDrawerDisabledException $e) {
             return response()->json([
                 'success' => false,
@@ -1540,7 +1561,7 @@ class PurchasesController extends BaseApiController
 
         // Try to get store from Filament tenant first, then fall back to user's current store
         try {
-            $userStore = \Filament\Facades\Filament::getTenant();
+            $userStore = Filament::getTenant();
         } catch (\Throwable $e) {
             $userStore = null;
         }
@@ -1685,7 +1706,7 @@ class PurchasesController extends BaseApiController
         }
 
         if (isset($validated['cart']['customer_id']) && $validated['cart']['customer_id'] !== null && $validated['cart']['customer_id'] !== 0) {
-            $customerExists = \App\Models\ConnectedCustomer::query()
+            $customerExists = ConnectedCustomer::query()
                 ->where('id', (int) $validated['cart']['customer_id'])
                 ->where('stripe_account_id', $charge->store->stripe_account_id)
                 ->exists();
@@ -1739,6 +1760,12 @@ class PurchasesController extends BaseApiController
                     ],
                 ],
             ], 200);
+        } catch (StripeConnectedAccountInaccessible $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+                'errors' => $e->validationErrors(),
+            ], 422);
         } catch (ValidationException $e) {
             return response()->json([
                 'success' => false,
@@ -1780,7 +1807,7 @@ class PurchasesController extends BaseApiController
         $user = $request->user();
 
         try {
-            $userStore = \Filament\Facades\Filament::getTenant();
+            $userStore = Filament::getTenant();
         } catch (\Throwable $e) {
             $userStore = null;
         }
@@ -1859,7 +1886,7 @@ class PurchasesController extends BaseApiController
         }
 
         if (isset($validated['cart']['customer_id']) && $validated['cart']['customer_id'] !== null && $validated['cart']['customer_id'] !== 0) {
-            $customerExists = \App\Models\ConnectedCustomer::query()
+            $customerExists = ConnectedCustomer::query()
                 ->where('id', (int) $validated['cart']['customer_id'])
                 ->where('stripe_account_id', $charge->store->stripe_account_id)
                 ->exists();
@@ -1985,9 +2012,9 @@ class PurchasesController extends BaseApiController
             if ($customerId !== null && $customerId !== '' && $customerId !== 0) {
                 $posSessionId = $request->input('pos_session_id');
                 if ($posSessionId) {
-                    $posSession = \App\Models\PosSession::find($posSessionId);
+                    $posSession = PosSession::find($posSessionId);
                     if ($posSession && $posSession->store) {
-                        $customer = \App\Models\ConnectedCustomer::where('id', (int) $customerId)
+                        $customer = ConnectedCustomer::where('id', (int) $customerId)
                             ->where('stripe_account_id', $posSession->store->stripe_account_id)
                             ->exists();
 
@@ -2019,7 +2046,7 @@ class PurchasesController extends BaseApiController
         $user = $request->user();
 
         try {
-            $userStore = \Filament\Facades\Filament::getTenant();
+            $userStore = Filament::getTenant();
         } catch (\Throwable $e) {
             $userStore = null;
         }
@@ -2138,6 +2165,20 @@ class PurchasesController extends BaseApiController
                     ],
                 ],
             ], 201);
+        } catch (StripeConnectedAccountInaccessible $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+                'errors' => $e->validationErrors(),
+            ], 422);
+        } catch (ValidationException $e) {
+            $errors = $e->errors();
+
+            return response()->json([
+                'success' => false,
+                'message' => Arr::flatten($errors)[0] ?? $e->getMessage(),
+                'errors' => $errors,
+            ], 422);
         } catch (CashDrawerDisabledException $e) {
             return response()->json([
                 'success' => false,
@@ -2243,13 +2284,13 @@ class PurchasesController extends BaseApiController
         }
 
         // Log void transaction event (13014)
-        \App\Models\PosEvent::create([
+        PosEvent::create([
             'store_id' => $store->id,
             'pos_device_id' => $posSession->pos_device_id,
             'pos_session_id' => $posSession->id,
             'user_id' => $request->user()->id,
             'related_charge_id' => $purchase->id,
-            'event_code' => \App\Models\PosEvent::EVENT_VOID_TRANSACTION,
+            'event_code' => PosEvent::EVENT_VOID_TRANSACTION,
             'event_type' => 'transaction',
             'description' => "Purchase cancelled: {$purchase->description}",
             'event_data' => [
@@ -2550,7 +2591,7 @@ class PurchasesController extends BaseApiController
 
         // If there's a payment intent, try to get additional details
         if ($purchase->stripe_payment_intent_id) {
-            $paymentIntent = \App\Models\ConnectedPaymentIntent::where('stripe_id', $purchase->stripe_payment_intent_id)
+            $paymentIntent = ConnectedPaymentIntent::where('stripe_id', $purchase->stripe_payment_intent_id)
                 ->where('stripe_account_id', $purchase->stripe_account_id)
                 ->first();
 

--- a/app/Http/Controllers/Stores/StoreTerminalPaymentIntentController.php
+++ b/app/Http/Controllers/Stores/StoreTerminalPaymentIntentController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers\Stores;
 
+use App\Exceptions\StripeConnectedAccountInaccessible;
 use App\Models\Store;
+use App\Support\Stripe\StripeConnectedAccountGate;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Stripe\Exception\PermissionException as StripePermissionException;
 use Stripe\StripeClient;
 use Throwable;
 
@@ -16,10 +19,10 @@ class StoreTerminalPaymentIntentController extends Controller
         // TODO: Authorize the caller (e.g. Sanctum / JWT / your own guard)
 
         $validated = $request->validate([
-            'amount'      => ['required', 'integer', 'min:1'],  // in minor units
-            'currency'    => ['nullable', 'string', 'size:3'],
+            'amount' => ['required', 'integer', 'min:1'],  // in minor units
+            'currency' => ['nullable', 'string', 'size:3'],
             'description' => ['nullable', 'string', 'max:255'],
-            'metadata'    => ['nullable', 'array'],
+            'metadata' => ['nullable', 'array'],
         ]);
 
         if (! $store->hasStripeAccount()) {
@@ -44,11 +47,16 @@ class StoreTerminalPaymentIntentController extends Controller
         $stripe = new StripeClient($secret);
 
         try {
+            StripeConnectedAccountGate::assertPlatformMayAccessConnectedAccount(
+                $stripe,
+                $store->stripe_account_id !== null ? (string) $store->stripe_account_id : null,
+            );
+
             $params = [
-                'amount'               => $validated['amount'],
-                'currency'             => $currency,
+                'amount' => $validated['amount'],
+                'currency' => $currency,
                 'payment_method_types' => ['card_present'],
-                'capture_method'       => 'automatic', // Terminal flow: create → collect → capture
+                'capture_method' => 'automatic', // Terminal flow: create → collect → capture
             ];
 
             if (! empty($validated['description'])) {
@@ -60,18 +68,27 @@ class StoreTerminalPaymentIntentController extends Controller
             }
 
             // Create PaymentIntent on the CONNECTED ACCOUNT
-            $intent = $stripe->paymentIntents->create(
-                $params,
-                ['stripe_account' => $store->stripe_account_id]
-            );
+            try {
+                $intent = $stripe->paymentIntents->create(
+                    $params,
+                    ['stripe_account' => $store->stripe_account_id]
+                );
+            } catch (StripePermissionException $stripePermissionException) {
+                StripeConnectedAccountGate::raiseIfDisconnectedConnectedAccountStripeCall($stripePermissionException);
+            }
 
             return response()->json($intent, 201);
+        } catch (StripeConnectedAccountInaccessible $e) {
+            return response()->json([
+                'message' => $e->getMessage(),
+                'errors' => $e->validationErrors(),
+            ], 422);
         } catch (Throwable $e) {
             report($e);
 
             return response()->json([
                 'message' => 'Failed to create payment intent.',
-                'error'   => $e->getMessage(),
+                'error' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Services/PurchaseService.php
+++ b/app/Services/PurchaseService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services;
 
+use App\Exceptions\CashDrawerDisabledException;
 use App\Models\ConnectedCharge;
+use App\Models\ConnectedCustomer;
 use App\Models\ConnectedProduct;
 use App\Models\PaymentMethod;
 use App\Models\PosEvent;
@@ -10,11 +12,14 @@ use App\Models\PosSession;
 use App\Models\ProductVariant;
 use App\Models\Receipt;
 use App\Models\Store;
+use App\Support\Stripe\StripeConnectedAccountGate;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use Stripe\Exception\InvalidRequestException;
+use Stripe\Exception\PermissionException as StripePermissionException;
 use Stripe\StripeClient;
 use Throwable;
 
@@ -70,7 +75,7 @@ class PurchaseService
         if (is_numeric($customerId)) {
             $customerIdInt = (int) $customerId;
 
-            $customer = \App\Models\ConnectedCustomer::where('id', $customerIdInt)
+            $customer = ConnectedCustomer::where('id', $customerIdInt)
                 ->where('stripe_account_id', $stripeAccountId)
                 ->first();
 
@@ -151,7 +156,7 @@ class PurchaseService
             if ($paymentMethod->isCash()) {
                 $device = $posSession->posDevice;
                 if ($device && $device->cash_drawer_enabled === false) {
-                    throw new \App\Exceptions\CashDrawerDisabledException;
+                    throw new CashDrawerDisabledException;
                 }
             }
 
@@ -309,6 +314,7 @@ class PurchaseService
 
         // Retrieve payment intent from Stripe with charges expanded
         $stripe = $this->getStripeClient();
+        StripeConnectedAccountGate::assertPlatformMayAccessConnectedAccount($stripe, $store->stripe_account_id);
 
         // Retry logic: sometimes charges take a moment to appear after confirmation
         $maxRetries = 3;
@@ -317,11 +323,15 @@ class PurchaseService
         $stripeChargeId = null;
 
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
-            $paymentIntent = $stripe->paymentIntents->retrieve(
-                $paymentIntentId,
-                ['expand' => ['charges.data']], // Expand charges to ensure they're loaded
-                ['stripe_account' => $store->stripe_account_id]
-            );
+            try {
+                $paymentIntent = $stripe->paymentIntents->retrieve(
+                    $paymentIntentId,
+                    ['expand' => ['charges.data']], // Expand charges to ensure they're loaded
+                    ['stripe_account' => $store->stripe_account_id]
+                );
+            } catch (StripePermissionException $e) {
+                StripeConnectedAccountGate::raiseIfDisconnectedConnectedAccountStripeCall($e);
+            }
 
             if ($paymentIntent->status !== 'succeeded') {
                 throw new \Exception('Payment intent is not succeeded');
@@ -674,11 +684,17 @@ class PurchaseService
             }
 
             $stripe = $this->getStripeClient();
-            $paymentIntent = $stripe->paymentIntents->retrieve(
-                $paymentIntentId,
-                [],
-                ['stripe_account' => $store->stripe_account_id]
-            );
+            StripeConnectedAccountGate::assertPlatformMayAccessConnectedAccount($stripe, $store->stripe_account_id);
+
+            try {
+                $paymentIntent = $stripe->paymentIntents->retrieve(
+                    $paymentIntentId,
+                    [],
+                    ['stripe_account' => $store->stripe_account_id]
+                );
+            } catch (StripePermissionException $e) {
+                StripeConnectedAccountGate::raiseIfDisconnectedConnectedAccountStripeCall($e);
+            }
 
             if ($paymentIntent->status !== 'succeeded') {
                 throw ValidationException::withMessages([
@@ -944,11 +960,17 @@ class PurchaseService
                 }
 
                 $stripe = $this->getStripeClient();
-                $paymentIntent = $stripe->paymentIntents->retrieve(
-                    $paymentIntentId,
-                    ['expand' => ['charges.data']],
-                    ['stripe_account' => $store->stripe_account_id]
-                );
+                StripeConnectedAccountGate::assertPlatformMayAccessConnectedAccount($stripe, $store->stripe_account_id);
+
+                try {
+                    $paymentIntent = $stripe->paymentIntents->retrieve(
+                        $paymentIntentId,
+                        ['expand' => ['charges.data']],
+                        ['stripe_account' => $store->stripe_account_id]
+                    );
+                } catch (StripePermissionException $e) {
+                    StripeConnectedAccountGate::raiseIfDisconnectedConnectedAccountStripeCall($e);
+                }
 
                 if ($paymentIntent->status !== 'succeeded') {
                     throw new \Exception('Payment intent is not succeeded');
@@ -1045,7 +1067,7 @@ class PurchaseService
             } elseif ($paymentMethod->isCash()) {
                 $device = $posSession->posDevice;
                 if ($device && $device->cash_drawer_enabled === false) {
-                    throw new \App\Exceptions\CashDrawerDisabledException;
+                    throw new CashDrawerDisabledException;
                 }
 
                 // Handle cash payment
@@ -1364,7 +1386,7 @@ class PurchaseService
                 'error' => null,
                 'payment_intent' => $paymentIntent,
             ];
-        } catch (\Stripe\Exception\InvalidRequestException $e) {
+        } catch (InvalidRequestException $e) {
             // Payment intent might already be cancelled, succeeded, or not found
             // This is not necessarily an error - it might already be in the desired state
             return [
@@ -1457,7 +1479,7 @@ class PurchaseService
                 }
 
                 if ($paymentMethod->isCash() && $hasCashDrawerDisabled) {
-                    throw new \App\Exceptions\CashDrawerDisabledException;
+                    throw new CashDrawerDisabledException;
                 }
 
                 // Process individual payment
@@ -1898,7 +1920,7 @@ class PurchaseService
                 'error' => null,
                 'refund' => $refund,
             ];
-        } catch (\Stripe\Exception\InvalidRequestException $e) {
+        } catch (InvalidRequestException $e) {
             Log::error('Stripe refund failed', [
                 'charge_id' => $stripeChargeId,
                 'stripe_account_id' => $stripeAccountId,

--- a/app/Support/Stripe/StripeConnectedAccountGate.php
+++ b/app/Support/Stripe/StripeConnectedAccountGate.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Support\Stripe;
+
+use App\Exceptions\StripeConnectedAccountInaccessible;
+use Stripe\Exception\PermissionException;
+use Stripe\StripeClient;
+
+final class StripeConnectedAccountGate
+{
+    /**
+     * Ensure the platform secret key may act on $stripeConnectedAccountId before making Connect requests
+     * (Stripe-Account / stripe_account header).
+     *
+     * @throws StripeConnectedAccountInaccessible When this platform cannot manage the linked connected account ID
+     * @throws PermissionException When Stripe reports unrelated permission denial
+     */
+    public static function assertPlatformMayAccessConnectedAccount(
+        StripeClient $stripe,
+        ?string $stripeConnectedAccountId,
+        string $messageKey = 'stripe_account'
+    ): void {
+        if ($stripeConnectedAccountId === null || trim($stripeConnectedAccountId) === '') {
+            throw StripeConnectedAccountInaccessible::generic($messageKey);
+        }
+
+        try {
+            $stripe->accounts->retrieve($stripeConnectedAccountId);
+        } catch (PermissionException $exception) {
+            self::throwAsInaccessibleStripeConnectUnlessUnrelated($exception, $messageKey);
+        }
+    }
+
+    /**
+     * Normalize Stripe PermissionException failures on Connect-context calls where the Stripe-Account is invalid/disconnected.
+     *
+     * @throws StripeConnectedAccountInaccessible
+     */
+    public static function raiseIfDisconnectedConnectedAccountStripeCall(
+        PermissionException $exception,
+        string $messageKey = 'stripe_account'
+    ): void {
+        self::throwAsInaccessibleStripeConnectUnlessUnrelated($exception, $messageKey);
+    }
+
+    protected static function throwAsInaccessibleStripeConnectUnlessUnrelated(
+        PermissionException $exception,
+        string $messageKey
+    ): void {
+        $normalized = strtolower($exception->getMessage());
+
+        $matchesInaccessibleConnectedAccount = str_contains($normalized, 'does not have access')
+            && str_contains($normalized, 'connected account');
+
+        $matchesOnBehalfWording = str_contains($normalized, 'cannot be used to perform requests on behalf')
+            || str_contains($normalized, "can't be used to perform requests");
+
+        $matchesStripeAccountHeaderIssue = str_contains($normalized, 'stripe-account header');
+
+        if ($matchesInaccessibleConnectedAccount || $matchesOnBehalfWording || $matchesStripeAccountHeaderIssue) {
+            throw StripeConnectedAccountInaccessible::generic($messageKey);
+        }
+
+        throw $exception;
+    }
+}

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Unit/Support/Stripe/StripeConnectedAccountGateTest.php
+++ b/tests/Unit/Support/Stripe/StripeConnectedAccountGateTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Exceptions\StripeConnectedAccountInaccessible;
+use App\Support\Stripe\StripeConnectedAccountGate;
+use PHPUnit\Framework\Assert;
+use Stripe\Exception\PermissionException;
+use Stripe\StripeClient;
+
+it('raises StripeConnectedAccountInaccessible when the platform cannot retrieve the connected account', function (): void {
+    $accountApi = Mockery::mock();
+    $accountApi->shouldReceive('retrieve')
+        ->once()
+        ->with('acct_inaccessible_example')
+        ->andThrow(PermissionException::factory(
+            'The provided key \'sk_live_***\' does not have access to connected account acct_inaccessible_example (or such connected account does not exist), or application is not authenticated to retrieve this account.'
+        ));
+
+    $stripe = Mockery::mock(StripeClient::class);
+    $stripe->accounts = $accountApi;
+
+    try {
+        StripeConnectedAccountGate::assertPlatformMayAccessConnectedAccount(
+            $stripe,
+            'acct_inaccessible_example',
+        );
+
+        Assert::fail('expected StripeConnectedAccountInaccessible');
+    } catch (StripeConnectedAccountInaccessible $e) {
+        expect($e->getMessage())->toBe(StripeConnectedAccountInaccessible::USER_MESSAGE);
+        expect($e->validationErrors())->toBe([
+            'stripe_account' => [StripeConnectedAccountInaccessible::USER_MESSAGE],
+        ]);
+    }
+});
+
+it('passes when the connected account is retrievable', function (): void {
+    $accountApi = Mockery::mock();
+    $accountApi->shouldReceive('retrieve')
+        ->once()
+        ->with('acct_connected_ok')
+        ->andReturn(['id' => 'acct_connected_ok']);
+
+    $stripe = Mockery::mock(StripeClient::class);
+    $stripe->accounts = $accountApi;
+
+    StripeConnectedAccountGate::assertPlatformMayAccessConnectedAccount(
+        $stripe,
+        'acct_connected_ok',
+    );
+
+    expect(true)->toBeTrue();
+});
+
+it('rethrows Stripe PermissionExceptions that are unrelated to disconnected connected-account access', function (): void {
+    $stripeException = PermissionException::factory(
+        'This API key lacks the stripe.pos.write permission.'
+    );
+
+    expect(fn (): mixed => StripeConnectedAccountGate::raiseIfDisconnectedConnectedAccountStripeCall($stripeException))
+        ->toThrow(PermissionException::class);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes tracked in GitHub [#105](https://github.com/janiator/filament-pos-stripe/issues/105) (Nightwatch **nw-ref-42**, NW [#42](https://github.com/janiator/filament-pos-stripe/issues/105)).

## Cause

Stripe Connect calls for the POS/mobile API use `stripe_account` against the linked `stripe_account_id`. When that ID is stale, disconnected, or no longer reachable with the platform keys (different Stripe Connect app/environment, onboarding reset, wrong account id), Stripe raises `Stripe\Exception\PermissionException` (e.g. “key does not have access to connected account”). Previously that surfaced as opaque server failures instead of a clear, actionable response.

## Fix

- Added `StripeConnectedAccountGate`: pre-validates connectivity with Stripe’s **Retrieve Account** (`GET /v1/accounts/:id`) before Connect-scoped work, and normalizes Stripe’s Connect-scope permission wording into `StripeConnectedAccountInaccessible`.
- Wired the gate into `PurchaseService` (PaymentIntent retrieves for Stripe card sales and deferred completion / cart reconciliation) and `StoreTerminalPaymentIntentController` (with a defensive mapper on PI create failures).
- `PurchasesController` and terminal PI controller return **422** with `success: false`, top-level message, and `errors.stripe_account` for FlutterFlow/clients instead of bubbling the raw Stripe exception.

**Bootstrap note:** Updated two local Filament/Webflow Page `static getUrl()` overrides to match upstream `Filament\Pages\Page::getUrl(...)` signatures (additional parameters). Without that, PHP emitted a fatal error at boot (`artisan`, tests touching the HTTP kernel). This change is mechanically required for Laravel/Filament v4 parity in this repo, not Stripe business logic.

## How to verify

```bash
php artisan test tests/Unit/Support/Stripe/StripeConnectedAccountGateTest.php
```

For interactive checks: configure a store with a `stripe_account_id` Stripe cannot operate on for your current secret key; invoking terminal PaymentIntent creation or a Stripe-backed purchase/completion flow should yield **422** with the readable `stripe_account` error payload instead of a `PermissionException`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38e7c7ec-5d8c-4613-982a-481c6699a145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38e7c7ec-5d8c-4613-982a-481c6699a145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

