### PR TITLE
fix(stripe): Guard terminal Connect routes for inaccessible accounts (Nightwatch nw-ref-43)

### DIFF
--- a/app/Exceptions/StripeConnectedAccountInaccessible.php
+++ b/app/Exceptions/StripeConnectedAccountInaccessible.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Exceptions;
+
+use Stripe\Exception\PermissionException;
+
+class StripeConnectedAccountInaccessible extends \RuntimeException
+{
+    public static function fromPermissionException(PermissionException $previous): self
+    {
+        return new self(
+            'This store\'s Stripe account is not accessible with the current platform credentials. Reconnect Stripe for this store or contact support.',
+            0,
+            $previous
+        );
+    }
+}

--- a/app/Http/Controllers/Stores/StoreTerminalConnectionTokenController.php
+++ b/app/Http/Controllers/Stores/StoreTerminalConnectionTokenController.php
@@ -2,12 +2,17 @@
 
 namespace App\Http\Controllers\Stores;
 
+use App\Exceptions\StripeConnectedAccountInaccessible;
 use App\Models\PosDevice;
 use App\Models\Store;
 use App\Models\TerminalLocation;
+use App\Support\Stripe\StripeConnectedAccountGate;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Stripe\Exception\PermissionException;
+use Stripe\StripeClient;
+use Throwable;
 
 class StoreTerminalConnectionTokenController extends Controller
 {
@@ -83,9 +88,39 @@ class StoreTerminalConnectionTokenController extends Controller
             }
         }
 
-        $connectionToken = $storeModel->createConnectionToken([
-            'location' => $location->stripe_location_id,
-        ], true); // true = connected account
+        $secret = config('cashier.secret') ?? config('services.stripe.secret');
+
+        if (! $secret) {
+            return response()->json([
+                'message' => 'Stripe secret key is not configured.',
+            ], 500);
+        }
+
+        $stripe = new StripeClient($secret);
+
+        try {
+            StripeConnectedAccountGate::assertPlatformMayUseConnectedAccount(
+                $stripe,
+                (string) $storeModel->stripe_account_id
+            );
+
+            $connectionToken = $storeModel->createConnectionToken([
+                'location' => $location->stripe_location_id,
+            ], true); // true = connected account
+        } catch (StripeConnectedAccountInaccessible $e) {
+            return $this->stripeConnectedAccountErrorResponse($e->getMessage());
+        } catch (PermissionException $e) {
+            return $this->stripeConnectedAccountErrorResponse(
+                StripeConnectedAccountInaccessible::fromPermissionException($e)->getMessage()
+            );
+        } catch (Throwable $e) {
+            report($e);
+
+            return response()->json([
+                'message' => 'Failed to create terminal connection token.',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
 
         $payload = [
             'secret' => $connectionToken->secret,
@@ -98,5 +133,16 @@ class StoreTerminalConnectionTokenController extends Controller
         }
 
         return response()->json($payload, 200);
+    }
+
+    private function stripeConnectedAccountErrorResponse(string $message): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors' => [
+                'stripe_account' => [$message],
+            ],
+        ], 422);
     }
 }

--- a/app/Http/Controllers/Stores/StoreTerminalPaymentIntentController.php
+++ b/app/Http/Controllers/Stores/StoreTerminalPaymentIntentController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers\Stores;
 
+use App\Exceptions\StripeConnectedAccountInaccessible;
 use App\Models\Store;
+use App\Support\Stripe\StripeConnectedAccountGate;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Stripe\Exception\PermissionException;
 use Stripe\StripeClient;
 use Throwable;
 
@@ -16,10 +19,10 @@ class StoreTerminalPaymentIntentController extends Controller
         // TODO: Authorize the caller (e.g. Sanctum / JWT / your own guard)
 
         $validated = $request->validate([
-            'amount'      => ['required', 'integer', 'min:1'],  // in minor units
-            'currency'    => ['nullable', 'string', 'size:3'],
+            'amount' => ['required', 'integer', 'min:1'],  // in minor units
+            'currency' => ['nullable', 'string', 'size:3'],
             'description' => ['nullable', 'string', 'max:255'],
-            'metadata'    => ['nullable', 'array'],
+            'metadata' => ['nullable', 'array'],
         ]);
 
         if (! $store->hasStripeAccount()) {
@@ -44,11 +47,16 @@ class StoreTerminalPaymentIntentController extends Controller
         $stripe = new StripeClient($secret);
 
         try {
+            StripeConnectedAccountGate::assertPlatformMayUseConnectedAccount(
+                $stripe,
+                (string) $store->stripe_account_id
+            );
+
             $params = [
-                'amount'               => $validated['amount'],
-                'currency'             => $currency,
+                'amount' => $validated['amount'],
+                'currency' => $currency,
                 'payment_method_types' => ['card_present'],
-                'capture_method'       => 'automatic', // Terminal flow: create → collect → capture
+                'capture_method' => 'automatic', // Terminal flow: create → collect → capture
             ];
 
             if (! empty($validated['description'])) {
@@ -66,13 +74,30 @@ class StoreTerminalPaymentIntentController extends Controller
             );
 
             return response()->json($intent, 201);
+        } catch (StripeConnectedAccountInaccessible $e) {
+            return $this->stripeConnectedAccountErrorResponse($e->getMessage());
+        } catch (PermissionException $e) {
+            return $this->stripeConnectedAccountErrorResponse(
+                StripeConnectedAccountInaccessible::fromPermissionException($e)->getMessage()
+            );
         } catch (Throwable $e) {
             report($e);
 
             return response()->json([
                 'message' => 'Failed to create payment intent.',
-                'error'   => $e->getMessage(),
+                'error' => $e->getMessage(),
             ], 500);
         }
+    }
+
+    private function stripeConnectedAccountErrorResponse(string $message): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors' => [
+                'stripe_account' => [$message],
+            ],
+        ], 422);
     }
 }

--- a/app/Support/Stripe/StripeConnectedAccountGate.php
+++ b/app/Support/Stripe/StripeConnectedAccountGate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support\Stripe;
+
+use App\Exceptions\StripeConnectedAccountInaccessible;
+use Stripe\Exception\PermissionException;
+use Stripe\StripeClient;
+
+final class StripeConnectedAccountGate
+{
+    public static function assertPlatformMayUseConnectedAccount(StripeClient $stripe, string $stripeAccountId): void
+    {
+        if ($stripeAccountId === '') {
+            throw new StripeConnectedAccountInaccessible('This store has no Stripe connected account.');
+        }
+
+        try {
+            $stripe->accounts->retrieve($stripeAccountId);
+        } catch (PermissionException $e) {
+            throw StripeConnectedAccountInaccessible::fromPermissionException($e);
+        }
+    }
+}

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -2,11 +2,16 @@
 
 namespace Positiv\FilamentWebflow\Filament\Pages;
 
+use App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection;
+use App\Models\EventTicket;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -17,12 +22,14 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 use Positiv\FilamentWebflow\Jobs\PullWebflowItems;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
 use Positiv\FilamentWebflow\Support\WebflowFieldData;
+use Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder;
 
 class WebflowCollectionItemsPage extends Page implements HasTable
 {
@@ -91,7 +98,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             IconColumn::make('is_draft')->label('Draft')->boolean()->toggleable(),
         ];
 
-        $schema = \Positiv\FilamentWebflow\Support\WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
+        $schema = WebflowSchemaFormBuilder::orderSchemaFields($collection->schema ?? []);
         foreach ($schema as $field) {
             $slug = $field['slug'] ?? null;
             if (! $slug) {
@@ -120,11 +127,11 @@ class WebflowCollectionItemsPage extends Page implements HasTable
 
         $columns[] = TextColumn::make('last_synced_at')->label('Last synced')->dateTime()->sortable()->toggleable();
 
-        if (class_exists(\App\Models\EventTicket::class)) {
+        if (class_exists(EventTicket::class)) {
             $columns[] = TextColumn::make('event_ticket_status')
                 ->label('Event ticket')
                 ->getStateUsing(function (WebflowItem $record): string {
-                    $linked = \App\Models\EventTicket::where('webflow_item_id', $record->id)->exists();
+                    $linked = EventTicket::where('webflow_item_id', $record->id)->exists();
 
                     return $linked ? 'Linked' : '—';
                 })
@@ -166,14 +173,14 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->icon('heroicon-o-arrow-down-tray')
                     ->action(function (): void {
                         PullWebflowItems::dispatch($this->collectionModel);
-                        \Filament\Notifications\Notification::make()
+                        Notification::make()
                             ->title('Pull queued')
                             ->body('Items will be synced from Webflow shortly.')
                             ->success()
                             ->send();
                         $user = auth()->user();
                         if ($user) {
-                            \Filament\Notifications\Notification::make()
+                            Notification::make()
                                 ->title('Pull queued')
                                 ->body('Items will be synced from Webflow shortly.')
                                 ->success()
@@ -189,13 +196,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     ->label('Edit')
                     ->icon('heroicon-o-pencil-square')
                     ->url($editPageUrl),
-                \Filament\Actions\Action::make('pushToWebflow')
+                Action::make('pushToWebflow')
                     ->label('Push to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn (WebflowItem $record) => PushWebflowItem::dispatch($record, false)),
             ])
             ->bulkActions([
-                \Filament\Actions\BulkAction::make('pushSelected')
+                BulkAction::make('pushSelected')
                     ->label('Push selected to Webflow')
                     ->icon('heroicon-o-arrow-up-tray')
                     ->action(fn ($records) => $records->each(fn (WebflowItem $r) => PushWebflowItem::dispatch($r, false)))
@@ -208,7 +215,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         if (! $this->collectionModel?->use_for_event_tickets) {
             return null;
         }
-        if (! class_exists(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class)) {
+        if (! class_exists(ImportEventTicketsFromWebflowCollection::class)) {
             return null;
         }
 
@@ -224,7 +231,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             ->action(function (array $data): void {
                 $tenant = Filament::getTenant();
                 if (! $tenant) {
-                    \Filament\Notifications\Notification::make()
+                    Notification::make()
                         ->title('No store selected')
                         ->body('Please select a store (tenant) first.')
                         ->danger()
@@ -233,10 +240,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
                     return;
                 }
 
-                $import = app(\App\Actions\EventTickets\ImportEventTicketsFromWebflowCollection::class);
+                $import = app(ImportEventTicketsFromWebflowCollection::class);
                 $result = $import($tenant, $this->collectionModel, (bool) ($data['pull_first'] ?? false));
 
-                \Filament\Notifications\Notification::make()
+                Notification::make()
                     ->title('Sync complete')
                     ->body("Created: {$result['created']}, Updated: {$result['updated']}.")
                     ->success()
@@ -244,13 +251,13 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items';
     }

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Panel;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\EmbeddedSchema;
 use Filament\Schemas\Components\Form;
@@ -14,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Positiv\FilamentWebflow\Jobs\PushWebflowItem;
 use Positiv\FilamentWebflow\Models\WebflowCollection;
 use Positiv\FilamentWebflow\Models\WebflowItem;
@@ -98,14 +100,14 @@ class WebflowItemEditPage extends Page
             : 'Edit CMS Item';
     }
 
-    public static function getSlug(?\Filament\Panel $panel = null): string
+    public static function getSlug(?Panel $panel = null): string
     {
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Feature/StoreTerminalConnectionTokenTest.php
+++ b/tests/Feature/StoreTerminalConnectionTokenTest.php
@@ -6,8 +6,15 @@ use App\Models\TerminalLocation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\CurlClient;
+use Tests\Support\StripePermissionDeniedTestHttpClient;
 
 uses(RefreshDatabase::class);
+
+afterEach(function (): void {
+    ApiRequestor::setHttpClient(CurlClient::instance());
+});
 
 it('returns 404 when pos_device_id is not found for store', function (): void {
     $user = User::factory()->create();
@@ -27,3 +34,60 @@ it('returns 404 when pos_device_id is not found for store', function (): void {
     $response->assertJson(['message' => 'POS device not found for this store.']);
 });
 
+it('returns 422 when stripe denies platform access to the connected account (connection token)', function (): void {
+    config()->set('cashier.secret', 'sk_test_permission_denied');
+    ApiRequestor::setHttpClient(new StripePermissionDeniedTestHttpClient);
+
+    $user = User::factory()->create();
+    $store = Store::factory()->create([
+        'slug' => 'nw43-token-store',
+        'stripe_account_id' => 'acct_nw43_example',
+    ]);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    $location = TerminalLocation::create([
+        'store_id' => $store->id,
+        'stripe_location_id' => 'tml_test_nw43',
+        'display_name' => 'Counter',
+        'line1' => 'Gate test',
+        'city' => 'Oslo',
+        'postal_code' => '0123',
+        'country' => 'NO',
+    ]);
+    $store->update(['default_terminal_location_id' => $location->id]);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->postJson('/api/stores/nw43-token-store/terminal/connection-token', []);
+
+    $response->assertUnprocessable();
+    $response->assertJsonPath('success', false);
+    expect($response->json('errors.stripe_account'))->toBeArray();
+    expect($response->json('message'))->toContain('not accessible');
+});
+
+it('returns 422 when stripe denies platform access to the connected account (terminal payment intent)', function (): void {
+    config()->set('cashier.secret', 'sk_test_permission_denied');
+    ApiRequestor::setHttpClient(new StripePermissionDeniedTestHttpClient);
+
+    $user = User::factory()->create();
+    $store = Store::factory()->create([
+        'slug' => 'nw43-pi-store',
+        'stripe_account_id' => 'acct_nw43_pi_example',
+    ]);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->postJson('/api/stores/nw43-pi-store/terminal/payment-intents', [
+        'amount' => 1000,
+        'currency' => 'nok',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonPath('success', false);
+    expect($response->json('errors.stripe_account'))->toBeArray();
+    expect($response->json('message'))->toContain('not accessible');
+});

--- a/tests/Support/StripePermissionDeniedTestHttpClient.php
+++ b/tests/Support/StripePermissionDeniedTestHttpClient.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Support;
+
+use Stripe\Exception\PermissionException;
+use Stripe\HttpClient\ClientInterface;
+
+/**
+ * Returns a Stripe-style 403 so the PHP SDK raises {@see PermissionException}.
+ */
+final class StripePermissionDeniedTestHttpClient implements ClientInterface
+{
+    public function __construct(
+        private readonly string $message = 'This API key does not have permission to perform this action on account acct_example. This may be due to duplicate account access.'
+    ) {}
+
+    /**
+     * @param  'delete'|'get'|'post'  $method
+     * @param  array<string, mixed>  $params
+     * @param  'v1'|'v2'  $apiMode
+     * @return array{0: string, 1: int, 2: array<string, mixed>}
+     */
+    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1')
+    {
+        $body = json_encode([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => $this->message,
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        return [$body, 403, []];
+    }
+}

--- a/tests/Unit/Support/Stripe/StripeConnectedAccountGateTest.php
+++ b/tests/Unit/Support/Stripe/StripeConnectedAccountGateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Exceptions\StripeConnectedAccountInaccessible;
+use App\Support\Stripe\StripeConnectedAccountGate;
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\CurlClient;
+use Stripe\StripeClient;
+use Tests\Support\StripePermissionDeniedTestHttpClient;
+
+afterEach(function (): void {
+    ApiRequestor::setHttpClient(CurlClient::instance());
+});
+
+it('throws when the connected account id is empty', function (): void {
+    expect(fn () => StripeConnectedAccountGate::assertPlatformMayUseConnectedAccount(
+        new StripeClient('sk_test_empty_acct'),
+        ''
+    ))->toThrow(StripeConnectedAccountInaccessible::class);
+});
+
+it('wraps stripe permission errors for connected account retrieve', function (): void {
+    ApiRequestor::setHttpClient(new StripePermissionDeniedTestHttpClient);
+
+    expect(fn () => StripeConnectedAccountGate::assertPlatformMayUseConnectedAccount(
+        new StripeClient('sk_test_gate'),
+        'acct_gate_example'
+    ))->toThrow(StripeConnectedAccountInaccessible::class);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/janiator/filament-pos-stripe/issues/107 (Nightwatch **nw-ref-43**).

## Cause

Stripe Terminal API routes create **connection tokens** and **PaymentIntents** on the connected account using the platform secret plus `Stripe-Account` / Connect options. When the stored `stripe_account_id` is wrong, disconnected, or the platform key no longer has access (including “duplicate account access” / Connect scope permission failures), Stripe raises `Stripe\Exception\PermissionException`. The connection-token action had no handling (uncaught exception); the payment-intent action caught errors but always called `report()`, which still surfaces as a Nightwatch exception for an expected client/store-configuration condition.

## Fix

- Added `StripeConnectedAccountGate::assertPlatformMayUseConnectedAccount()` to probe **`GET /v1/accounts/:id`** on the platform before Connect-scoped work.
- Mapped access failures to `StripeConnectedAccountInaccessible` and return **HTTP 422** with `success: false`, `message`, and `errors.stripe_account` on:
  - `POST /api/stores/{store}/terminal/connection-token`
  - `POST /api/stores/{store}/terminal/payment-intents`
- Avoid `report()` for these expected permission failures (still report unexpected errors).
- **Bootstrap:** updated `Page::getUrl()` overrides in bundled `filament-webflow` to match Filament v4 (`shouldGuessMissingParameters`, `configuration`), so `php artisan test` and the HTTP kernel can load without a fatal signature mismatch (same mechanical change as draft PR #106).

## How to verify

```bash
php artisan test --compact tests/Unit/Support/Stripe/StripeConnectedAccountGateTest.php
php artisan test --compact tests/Feature/StoreTerminalConnectionTokenTest.php
```

The feature file exercises the HTTP layer when a test database is available per `phpunit.xml` (PostgreSQL `pos_stripe_test`). The unit tests run without DB and assert the gate wraps Stripe 403/permission responses using a stub HTTP client.

With a store whose `stripe_account_id` the current secret key cannot access, both endpoints should return **422** and the structured `stripe_account` error payload instead of a thrown `PermissionException` / Nightwatch noise.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf3fb933-8acd-4708-9bad-c0355b8ad256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf3fb933-8acd-4708-9bad-c0355b8ad256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

