### PR TITLE
Fix SyncStoreStripeBalanceTransactionsJob retries when Store is missing (Nightwatch #44)

### DIFF
--- a/app/Jobs/SyncStoreStripeBalanceTransactionsJob.php
+++ b/app/Jobs/SyncStoreStripeBalanceTransactionsJob.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -16,6 +17,8 @@ use Illuminate\Support\Facades\Log;
 class SyncStoreStripeBalanceTransactionsJob implements ShouldBeUnique, ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public bool $deleteWhenMissingModels = true;
 
     public int $tries = 3;
 
@@ -49,7 +52,15 @@ class SyncStoreStripeBalanceTransactionsJob implements ShouldBeUnique, ShouldQue
         ]);
 
         try {
-            $this->store->refresh();
+            try {
+                $this->store->refresh();
+            } catch (ModelNotFoundException) {
+                Log::warning('Skipping Stripe balance transaction sync — store no longer exists', [
+                    'store_id' => $this->store->getKey(),
+                ]);
+
+                return;
+            }
 
             if (! $this->store->stripe_account_id) {
                 Log::warning('Skipping Stripe balance transaction sync — store has no Stripe account id', [

--- a/tests/Feature/SyncStoreStripeBalanceTransactionsJobTest.php
+++ b/tests/Feature/SyncStoreStripeBalanceTransactionsJobTest.php
@@ -5,6 +5,8 @@ use App\Jobs\SyncStoreStripeBalanceTransactionsJob;
 use App\Models\Store;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
+use Mockery;
+use ReflectionClass;
 
 uses(RefreshDatabase::class);
 
@@ -23,10 +25,10 @@ it('dispatches sync store stripe balance transactions job', function (): void {
 it('invokes balance transaction sync action when job runs', function (): void {
     $store = Store::factory()->create(['stripe_account_id' => 'acct_test_sync_bt_run']);
 
-    $sync = \Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
+    $sync = Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
     $sync->shouldReceive('__invoke')
         ->once()
-        ->with(\Mockery::on(fn (Store $s): bool => (int) $s->getKey() === (int) $store->getKey()), false, null)
+        ->with(Mockery::on(fn (Store $s): bool => (int) $s->getKey() === (int) $store->getKey()), false, null)
         ->andReturn(['total' => 3, 'created' => 0, 'updated' => 3, 'errors' => []]);
 
     $job = new SyncStoreStripeBalanceTransactionsJob($store);
@@ -36,10 +38,10 @@ it('invokes balance transaction sync action when job runs', function (): void {
 it('passes stripe payout id to balance transaction sync when job is payout-scoped', function (): void {
     $store = Store::factory()->create(['stripe_account_id' => 'acct_test_sync_bt_payout']);
 
-    $sync = \Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
+    $sync = Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
     $sync->shouldReceive('__invoke')
         ->once()
-        ->with(\Mockery::on(fn (Store $s): bool => (int) $s->getKey() === (int) $store->getKey()), false, 'po_scope_test')
+        ->with(Mockery::on(fn (Store $s): bool => (int) $s->getKey() === (int) $store->getKey()), false, 'po_scope_test')
         ->andReturn(['total' => 5, 'created' => 1, 'updated' => 4, 'errors' => []]);
 
     $job = new SyncStoreStripeBalanceTransactionsJob($store, 'po_scope_test');
@@ -49,9 +51,28 @@ it('passes stripe payout id to balance transaction sync when job is payout-scope
 it('skips sync when store has no stripe account id', function (): void {
     $store = Store::factory()->create(['stripe_account_id' => null]);
 
-    $sync = \Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
+    $sync = Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
     $sync->shouldNotReceive('__invoke');
 
     $job = new SyncStoreStripeBalanceTransactionsJob($store);
     $job->handle($sync);
+});
+
+it('skips sync when store was deleted before refresh without throwing', function (): void {
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_test_deleted_refresh']);
+
+    $sync = Mockery::mock(SyncStoreStripeBalanceTransactionsFromStripe::class);
+    $sync->shouldNotReceive('__invoke');
+
+    $job = new SyncStoreStripeBalanceTransactionsJob($store);
+    $store->delete();
+
+    $job->handle($sync);
+});
+
+it('is configured to delete from the queue when serialized store model no longer exists', function (): void {
+    $reflection = new ReflectionClass(SyncStoreStripeBalanceTransactionsJob::class);
+    $defaults = $reflection->getDefaultProperties();
+
+    expect($defaults['deleteWhenMissingModels'] ?? false)->toBeTrue();
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Tracking

- Closes https://github.com/janiator/filament-pos-stripe/issues/109
- **Nightwatch:** issue id `nw-ref-44` (NW [#44](https://github.com/janiator/filament-pos-stripe/issues/109))

## Cause

`SyncStoreStripeBalanceTransactionsJob` serializes a `Store` model and calls `refresh()` at the start of `handle()`. If the store row no longer exists when the worker processes the job (deleted tenant, cleanup, or a race after dispatch), `ModelNotFoundException` bubbles up. The job is retried until attempts are exhausted, which surfaces as `MaxAttemptsExceededException` in Nightwatch.

`SyncStoreStripeBalanceTransactionsFromStripe` already catches `Throwable` and returns a result, so it does not explain repeated failures; the durable failure is the missing model path.

## Fix

1. **`public bool $deleteWhenMissingModels = true`** — When Laravel fails to restore the `Store` from the queue payload (`CallQueuedHandler` / `SerializesModels`), the job is removed instead of failing and retrying ([Laravel docs: handling missing models](https://laravel.com/docs/queues#handling-missing-models)).
2. **Catch `ModelNotFoundException` around `refresh()`** — Log and exit successfully when the row disappeared after the model was restored (no pointless retries).

## How to verify

```bash
php artisan test --compact tests/Feature/SyncStoreStripeBalanceTransactionsJobTest.php
```

New coverage: deleted store before `handle()` does not invoke the sync action; `deleteWhenMissingModels` default is asserted on the job class.

**Note:** In this workspace, `php artisan test` currently fatals on a pre-existing Filament `Page::getUrl` signature mismatch in `packages/filament-webflow` (same on `origin/main`). After that is resolved upstream, the command above should pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19237a59-87aa-482d-a37d-a79c078fee62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19237a59-87aa-482d-a37d-a79c078fee62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

