### PR TITLE
Fix duplicate failed_jobs UUID on queued job failure (#111 / Nightwatch nw-ref-46)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,13 +2,22 @@
 
 namespace App\Providers;
 
+use App\Filament\Pages\WebflowItemEditPage;
+use App\Listeners\SyncProductOnMediaDeleted;
+use App\Observers\WebflowSiteObserver;
 use App\Policies\WebflowSitePolicy;
+use App\Queue\FailedJobs\DeduplicatingDatabaseUuidFailedJobProvider;
 use Filament\Support\Facades\FilamentTimezone;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\Query;
 use Positiv\FilamentWebflow\Models\WebflowSite;
+use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenClearedEvent;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,7 +26,17 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        if (config('queue.failed.driver') !== 'database-uuids') {
+            return;
+        }
+
+        $this->app->singleton('queue.failer', function (Application $app) {
+            return new DeduplicatingDatabaseUuidFailedJobProvider(
+                $app['db'],
+                (string) config('queue.failed.database'),
+                (string) config('queue.failed.table'),
+            );
+        });
     }
 
     /**
@@ -28,7 +47,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(WebflowSite::class, WebflowSitePolicy::class);
 
         config([
-            'filament-webflow.item_edit_page' => \App\Filament\Pages\WebflowItemEditPage::class,
+            'filament-webflow.item_edit_page' => WebflowItemEditPage::class,
         ]);
 
         Nightwatch::rejectQueries(function (Query $query) {
@@ -44,7 +63,7 @@ class AppServiceProvider extends ServiceProvider
 
         // Force HTTPS in local development when using Herd
         if (app()->environment('local') && str_starts_with(config('app.url', ''), 'https://')) {
-            \Illuminate\Support\Facades\URL::forceScheme('https');
+            URL::forceScheme('https');
         }
 
         // Configure Pulse authorization - allow all authenticated users
@@ -53,17 +72,17 @@ class AppServiceProvider extends ServiceProvider
         });
 
         // Register custom Media model for Spatie Media Library
-        \Spatie\MediaLibrary\MediaCollections\Models\Media::resolveRelationUsing('model', function ($mediaModel) {
+        Media::resolveRelationUsing('model', function ($mediaModel) {
             return $mediaModel->morphTo();
         });
 
         // Listen to media collection cleared events to trigger Stripe sync
-        \Illuminate\Support\Facades\Event::listen(
-            \Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenClearedEvent::class,
-            \App\Listeners\SyncProductOnMediaDeleted::class
+        Event::listen(
+            CollectionHasBeenClearedEvent::class,
+            SyncProductOnMediaDeleted::class
         );
 
         // When a Webflow site is deleted, remove EventTickets that referenced its items
-        \Positiv\FilamentWebflow\Models\WebflowSite::observe(\App\Observers\WebflowSiteObserver::class);
+        WebflowSite::observe(WebflowSiteObserver::class);
     }
 }

--- a/app/Queue/FailedJobs/DeduplicatingDatabaseUuidFailedJobProvider.php
+++ b/app/Queue/FailedJobs/DeduplicatingDatabaseUuidFailedJobProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Queue\FailedJobs;
+
+use Illuminate\Queue\Console\RetryCommand;
+use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
+
+/**
+ * Ensures inserting a failed job never violates failed_jobs.uuid uniqueness.
+ *
+ * Retried queue jobs reuse the payload UUID ({@see RetryCommand}),
+ * while the original failure may still occupy failed_jobs briefly. Laravel records the retry
+ * failure with the same UUID, triggering a duplicate-key error on PostgreSQL/MySQL/etc.
+ *
+ * Deleting any existing row for the payload UUID matches "latest failure wins" semantics.
+ */
+final class DeduplicatingDatabaseUuidFailedJobProvider extends DatabaseUuidFailedJobProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        $decodedPayload = json_decode($payload, true);
+
+        $uuid = is_array($decodedPayload) ? ($decodedPayload['uuid'] ?? null) : null;
+
+        if (is_string($uuid) && $uuid !== '') {
+            $this->getTable()->where('uuid', $uuid)->delete();
+        }
+
+        return parent::log($connection, $queue, $payload, $exception);
+    }
+}

--- a/tests/Unit/Queue/DeduplicatingDatabaseUuidFailedJobProviderTest.php
+++ b/tests/Unit/Queue/DeduplicatingDatabaseUuidFailedJobProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Queue;
+
+use App\Queue\FailedJobs\DeduplicatingDatabaseUuidFailedJobProvider;
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class DeduplicatingDatabaseUuidFailedJobProviderTest extends TestCase
+{
+    private Capsule $capsule;
+
+    private DeduplicatingDatabaseUuidFailedJobProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(new Container);
+
+        $this->capsule = new Capsule;
+        $this->capsule->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ], 'default');
+        $this->capsule->setAsGlobal();
+        $this->capsule->bootEloquent();
+
+        $schema = $this->capsule->getConnection()->getSchemaBuilder();
+
+        $schema->create('failed_jobs', function (Blueprint $table): void {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+
+        $this->provider = new DeduplicatingDatabaseUuidFailedJobProvider(
+            $this->capsule->getDatabaseManager(),
+            'default',
+            'failed_jobs',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->capsule->getConnection()->disconnect();
+
+        parent::tearDown();
+    }
+
+    public function test_it_logs_the_same_payload_uuid_twice_without_unique_violation(): void
+    {
+        $uuid = '018f3c4c-aaaa-7012-8566-aaaaaaaaaaaa';
+        $payload = '{"uuid":"'.$uuid.'"}';
+
+        $this->provider->log('redis', 'default', $payload, new RuntimeException('first'));
+        self::assertSame(
+            1,
+            $this->capsule->getConnection()->table('failed_jobs')->where('uuid', $uuid)->count(),
+        );
+
+        $this->provider->log('redis', 'default', $payload, new RuntimeException('second'));
+
+        self::assertSame(
+            1,
+            $this->capsule->getConnection()->table('failed_jobs')->where('uuid', $uuid)->count(),
+        );
+
+        $row = $this->capsule->getConnection()->table('failed_jobs')->where('uuid', $uuid)->first();
+
+        self::assertNotNull($row);
+        self::assertIsString($row->exception ?? null);
+        self::assertStringContainsString('second', $row->exception);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves regression reported in https://github.com/janiator/filament-pos-stripe/issues/111 (Nightwatch **nw-ref-46**, ref **#46**).

## Cause

Laravel assigns a UUID to each queued job payload. That same value is persisted as `failed_jobs.uuid` when logging failures (`database-uuids`). Retries/re-dispatches reuse the serialized payload—including the UUID—via `Illuminate\Queue\Console\RetryCommand` (`pushRaw`), while an older failure row may still occupy `failed_jobs` for that UUID briefly. Logging the retry failure then hits the `failed_jobs_uuid_unique` constraint (PostgreSQL-compatible unique index).

## Fix

Bind a small extension of Laravel’s `DatabaseUuidFailedJobProvider` that deletes any existing `failed_jobs` row matching the incoming payload UUID before delegating to the framework insert (“latest failure wins” for identical payload UUID).

## Verify

```
./vendor/bin/phpunit tests/Unit/Queue/DeduplicatingDatabaseUuidFailedJobProviderTest.php
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9263ed9b-91e7-403c-bfc1-26d711835e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9263ed9b-91e7-403c-bfc1-26d711835e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

