### PR TITLE
fix(nightwatch): harden Livewire snapshots for Filament Notifications (nw-ref-31)

### DIFF
--- a/app/Http/Middleware/GuardLivewireUpdatePayload.php
+++ b/app/Http/Middleware/GuardLivewireUpdatePayload.php
@@ -9,21 +9,115 @@ use Symfony\Component\HttpFoundation\Response;
 class GuardLivewireUpdatePayload
 {
     /**
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->is('livewire/update') && $request->isMethod('post') && $request->isJson()) {
-            $payload = $request->json()->all();
-            $components = $payload['components'] ?? null;
+        if ($request->is('livewire/update') && $request->isMethod('post')) {
+            $rejection = $this->rejectMalformedUpdateRequest($request->all());
 
-            if (! is_array($components)) {
-                return response()->json([
-                    'message' => 'Malformed Livewire update payload.',
-                ], 400);
+            if ($rejection instanceof Response) {
+                return $rejection;
             }
         }
 
         return $next($request);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function rejectMalformedUpdateRequest(array $payload): ?Response
+    {
+        $components = $payload['components'] ?? null;
+
+        if (! is_array($components)) {
+            return $this->livewireMalformedResponse();
+        }
+
+        foreach ($components as $componentPayload) {
+            if (! $this->isWellFormedWireComponentEnvelope($componentPayload)) {
+                return $this->livewireMalformedResponse();
+            }
+
+            /** @var array{snapshot: string, updates: array, calls: array} $componentPayload */
+            $snapshot = json_decode($componentPayload['snapshot'], true);
+
+            if (! is_array($snapshot)) {
+                return $this->livewireMalformedResponse();
+            }
+
+            if (! $this->hasValidDecodedSnapshotShape($snapshot)) {
+                return $this->livewireMalformedResponse();
+            }
+
+            if ($this->filamentNotificationsHasInvalidBooleanStamp($snapshot)) {
+                return $this->livewireMalformedResponse();
+            }
+        }
+
+        return null;
+    }
+
+    private function livewireMalformedResponse(): Response
+    {
+        return response()->json([
+            'message' => 'Malformed Livewire update payload.',
+        ], 400);
+    }
+
+    private function isWellFormedWireComponentEnvelope(mixed $componentPayload): bool
+    {
+        if (! is_array($componentPayload)) {
+            return false;
+        }
+
+        if (! isset($componentPayload['snapshot'], $componentPayload['updates'], $componentPayload['calls'])) {
+            return false;
+        }
+
+        if (! is_string($componentPayload['snapshot'])) {
+            return false;
+        }
+
+        if (! is_array($componentPayload['updates'])) {
+            return false;
+        }
+
+        return is_array($componentPayload['calls']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $snapshot
+     */
+    private function hasValidDecodedSnapshotShape(array $snapshot): bool
+    {
+        return is_array($snapshot['data'] ?? null)
+            && is_array($snapshot['memo'] ?? null)
+            && is_string($snapshot['checksum'] ?? null)
+            && is_string($snapshot['memo']['id'] ?? null)
+            && is_scalar($snapshot['memo']['name'] ?? null);
+    }
+
+    /**
+     * Livewire exposes Filament Notifications as the `notifications` component.
+     *
+     * @param  array<string, mixed>  $snapshot
+     */
+    private function filamentNotificationsHasInvalidBooleanStamp(array $snapshot): bool
+    {
+        $name = $snapshot['memo']['name'] ?? null;
+
+        if ($name !== 'notifications') {
+            return false;
+        }
+
+        if (! array_key_exists('isFilamentNotificationsComponent', $snapshot['data'])) {
+            return false;
+        }
+
+        $value = $snapshot['data']['isFilamentNotificationsComponent'];
+
+        return ! is_bool($value) && $value !== null;
     }
 }

--- a/tests/Feature/LivewireUpdateGuardTest.php
+++ b/tests/Feature/LivewireUpdateGuardTest.php
@@ -1,15 +1,59 @@
 <?php
 
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
 
 test('malformed livewire update payload is rejected early', function () {
     $this->withoutMiddleware(VerifyCsrfToken::class);
 
     $response = $this->postJson('/livewire/update', [
         '_nightwatch_error' => 'NOT_ENABLED',
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJsonPath('message', 'Malformed Livewire update payload.');
+});
+
+test('livewire update rejects invalid component envelope shapes', function () {
+    $this->withoutMiddleware(VerifyCsrfToken::class);
+
+    $response = $this->postJson('/livewire/update', [
+        'components' => [
+            [
+                'updates' => [],
+                'calls' => [],
+                'snapshot' => ['not-a-string'],
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJsonPath('message', 'Malformed Livewire update payload.');
+});
+
+test('notifications component rejects malformed isFilamentNotificationsComponent wire state before hydration', function () {
+    $this->withoutMiddleware(VerifyCsrfToken::class);
+
+    $snapshot = json_encode([
+        'memo' => [
+            'id' => 'not-a-real-id',
+            'name' => 'notifications',
+        ],
+        'data' => [
+            'isFilamentNotificationsComponent' => ['malformed'],
+        ],
+        'checksum' => 'not-verified-but-exists-as-string-for-shape-check',
+    ]);
+
+    assert(is_string($snapshot));
+
+    $response = $this->postJson('/livewire/update', [
+        'components' => [
+            [
+                'snapshot' => $snapshot,
+                'updates' => [],
+                'calls' => [],
+            ],
+        ],
     ]);
 
     $response->assertStatus(400)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracked by https://github.com/janiator/filament-pos-stripe/issues/113 (Nightwatch **nw-ref-31**, ref #31).

**Cause:** Automated clients sometimes POST JSON to `/livewire/update` with a structurally plausible Livewire component envelope whose decoded `snapshot` contains `memo.name === "notifications"` (Filament’s `notifications` Livewire component) but wire data where `isFilamentNotificationsComponent` is not hydrated as `null`/`true`/`false`—for example an array payload. Laravel Livewire’s `hydrateProperties` assigns that raw value onto `Filament\Notifications\Livewire\Notifications::$isFilamentNotificationsComponent` (declared `bool`), which surfaces as a fatal type error (`cannot assign array to bool ... isFilamentNotificationsComponent`).

**Fix:** Extend `GuardLivewireUpdatePayload` so POSTs to `/livewire/update` are validated using the merged request payload (`$request->all()` mirrors Livewire’s `components` input handling). Each component entry must expose `snapshot` (string JSON), `updates`, and `calls`. The decoded snapshot must match Livewire’s top-level skeleton (`data`, `memo`, `checksum`, `memo.id`, `memo.name`). For snapshots targeting the notifications component, reject `isFilamentNotificationsComponent` when it exists and is neither `bool` nor `null`, returning HTTP 400 with the existing malformed-payload JSON body before Livewire hydrates properties.

**How to verify:** `php artisan test --compact tests/Feature/LivewireUpdateGuardTest.php` (covers the prior missing-`components` guard, malformed envelopes, and the Filament Notifications bool/wire regression).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be2f43c6-2f9e-42d1-93b7-9db225dda58c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be2f43c6-2f9e-42d1-93b7-9db225dda58c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

