### PR TITLE
Guard Livewire update route against non-JSON bot probes (Nightwatch nw-ref-32)

### DIFF
--- a/app/Http/Middleware/GuardLivewireUpdatePayload.php
+++ b/app/Http/Middleware/GuardLivewireUpdatePayload.php
@@ -9,21 +9,42 @@ use Symfony\Component\HttpFoundation\Response;
 class GuardLivewireUpdatePayload
 {
     /**
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->is('livewire/update') && $request->isMethod('post') && $request->isJson()) {
-            $payload = $request->json()->all();
-            $components = $payload['components'] ?? null;
+        if (! $request->is('livewire/update') || ! $request->isMethod('post')) {
+            return $next($request);
+        }
 
-            if (! is_array($components)) {
-                return response()->json([
-                    'message' => 'Malformed Livewire update payload.',
-                ], 400);
+        if (! $request->isJson()) {
+            return $this->malformedPayloadResponse();
+        }
+
+        $payload = $request->json()->all();
+        $components = $payload['components'] ?? null;
+
+        if (! is_array($components) || $components === []) {
+            return $this->malformedPayloadResponse();
+        }
+
+        foreach ($components as $component) {
+            if (! is_array($component)
+                || ! is_string($component['snapshot'] ?? null)
+                || ! is_array($component['updates'] ?? null)
+                || ! is_array($component['calls'] ?? null)
+            ) {
+                return $this->malformedPayloadResponse();
             }
         }
 
         return $next($request);
+    }
+
+    private function malformedPayloadResponse(): Response
+    {
+        return response()->json([
+            'message' => 'Malformed Livewire update payload.',
+        ], 400);
     }
 }

--- a/tests/Feature/LivewireUpdateGuardTest.php
+++ b/tests/Feature/LivewireUpdateGuardTest.php
@@ -15,3 +15,31 @@ test('malformed livewire update payload is rejected early', function () {
     $response->assertStatus(400)
         ->assertJsonPath('message', 'Malformed Livewire update payload.');
 });
+
+test('non-json livewire update requests from probes are rejected early', function () {
+    $this->withoutMiddleware(VerifyCsrfToken::class);
+
+    $response = $this->post('/livewire/update', [
+        'components' => [
+            [
+                'snapshot' => '{}',
+                'updates' => [],
+                'calls' => [],
+            ],
+        ],
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJsonPath('message', 'Malformed Livewire update payload.');
+});
+
+test('livewire update json missing components shape is rejected early', function () {
+    $this->withoutMiddleware(VerifyCsrfToken::class);
+
+    $response = $this->postJson('/livewire/update', [
+        'components' => [],
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJsonPath('message', 'Malformed Livewire update payload.');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to https://github.com/janiator/filament-pos-stripe/issues/115 (Nightwatch **nw-ref-32**).

## Cause

`GuardLivewireUpdatePayload` only inspected JSON bodies when `$request->isJson()` was true. Automated probes (and similar clients) often `POST` to `/livewire/update` with non-JSON encodings. Those requests skipped the guard and reached Livewire hydration, which led to exceptions such as **Cannot update locked property `userUndertakingMultiFactorAuthentication`** on authenticated Filament flows.

## Fix

For `POST /livewire/update`:

1. Require an JSON request (`Content-Type` with `json`, same as real Livewire [`sendRequest`](https://github.com/livewire/livewire)).
2. Validate `components` the same way Livewire does in `HandleRequests::handleUpdate()` (non-empty array; each entry must have string `snapshot`, array `updates`, array `calls`).

Malformed probes now receive **400** with `{"message":"Malformed Livewire update payload."}` before Livewire runs.

## How to verify

1. Run `php artisan test --compact tests/Feature/LivewireUpdateGuardTest.php`.
2. Manually: `POST /livewire/update` with `Content-Type: application/x-www-form-urlencoded` (or without JSON) should return **400** and must not surface Livewire locked-property errors in logs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35495d7c-6059-4422-974b-c376cff4fca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35495d7c-6059-4422-974b-c376cff4fca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

