### PR TITLE
Fix Filament mounted actions without name (Nightwatch nw-ref-34)

### DIFF
--- a/app/Filament/MountedActionsSanitizer.php
+++ b/app/Filament/MountedActionsSanitizer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament;
+
+use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\Exceptions\ActionNotResolvableException;
+use Livewire\Component;
+
+final class MountedActionsSanitizer
+{
+    /**
+     * RichEditor and other schema components can persist entries on {@see HasActions::$mountedActions}
+     * that contain only serialized field state (`data`) without a `name`. Filament then throws
+     * {@see ActionNotResolvableException} while resolving mounted actions
+     * during Livewire dehydrate (modal partial render).
+     *
+     * @see https://github.com/filamentphp/filament/issues/17096
+     */
+    public static function sanitizeComponent(Component $component): void
+    {
+        if (! $component instanceof HasActions) {
+            return;
+        }
+
+        $mounted = $component->mountedActions ?? null;
+        if (! is_array($mounted) || $mounted === []) {
+            return;
+        }
+
+        $sanitized = [];
+        foreach ($mounted as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            if (! filled($entry['name'] ?? null)) {
+                continue;
+            }
+
+            $sanitized[] = $entry;
+        }
+
+        if (count($sanitized) !== count($mounted)) {
+            $component->mountedActions = $sanitized;
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace App\Providers;
 
+use App\Filament\MountedActionsSanitizer;
 use App\Policies\WebflowSitePolicy;
 use Filament\Support\Facades\FilamentTimezone;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\Query;
+use Livewire\Component;
+use Livewire\EventBus;
 use Positiv\FilamentWebflow\Models\WebflowSite;
 
 class AppServiceProvider extends ServiceProvider
@@ -25,6 +28,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $eventBus = $this->app->make(EventBus::class);
+
+        $eventBus->before('hydrate', function (Component $component): void {
+            MountedActionsSanitizer::sanitizeComponent($component);
+        });
+
+        $eventBus->before('dehydrate', function (Component $component): void {
+            MountedActionsSanitizer::sanitizeComponent($component);
+        });
+
         Gate::policy(WebflowSite::class, WebflowSitePolicy::class);
 
         config([

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -244,10 +244,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public static function getSlug(?\Filament\Panel $panel = null): string

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -103,9 +103,9 @@ class WebflowItemEditPage extends Page
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Unit/MountedActionsSanitizerTest.php
+++ b/tests/Unit/MountedActionsSanitizerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\MountedActionsSanitizer;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Livewire\Component;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('removes mounted action entries without a name', function (): void {
+    $component = new class extends Component implements HasActions
+    {
+        use InteractsWithActions;
+    };
+
+    $component->mountedActions = [
+        ['data' => ['description' => ['type' => 'doc', 'content' => []]]],
+    ];
+
+    MountedActionsSanitizer::sanitizeComponent($component);
+
+    expect($component->mountedActions)->toBe([]);
+});
+
+it('keeps only entries that declare a non-blank name', function (): void {
+    $component = new class extends Component implements HasActions
+    {
+        use InteractsWithActions;
+    };
+
+    $component->mountedActions = [
+        ['data' => ['description' => ['type' => 'doc', 'content' => []]]],
+        ['name' => 'generateSkus', 'arguments' => [], 'context' => []],
+    ];
+
+    MountedActionsSanitizer::sanitizeComponent($component);
+
+    expect($component->mountedActions)->toHaveCount(1)
+        ->and($component->mountedActions[0]['name'] ?? null)->toBe('generateSkus');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks https://github.com/janiator/filament-pos-stripe/issues/117

**Nightwatch:** `nw-ref-34` (NW #34)

## Cause

Filament can persist entries on the Livewire `mountedActions` stack that contain only serialized field `data` and **no `name`** (for example RichEditor state inside action modals; see [filamentphp/filament#17096](https://github.com/filamentphp/filament/issues/17096)). On the next Livewire update, Filament renders action partials and resolves mounted actions; `resolveActions()` then throws `Filament\Actions\Exceptions\ActionNotResolvableException` with message *An action tried to resolve without a name.*, wrapped as `Illuminate\View\ViewException`.

## Fix

- Register Livewire `EventBus::before('hydrate')` and `before('dehydrate')` callbacks that strip invalid `mountedActions` entries (non-array rows or rows without a non-blank `name`) using `App\Filament\MountedActionsSanitizer`, so bogus snapshots or editor artifacts cannot crash dehydrate.
- Align `positiv/filament-webflow` `Page::getUrl()` overrides with the current `Filament\Pages\Page::getUrl()` signature so PHP 8.4 can load those classes during bootstrap (required to run Artisan/tests in this repo).

## How to verify

```bash
php artisan test --compact tests/Unit/MountedActionsSanitizerTest.php
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3df9f987-8092-41bc-8848-4bfc6b2e7a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3df9f987-8092-41bc-8848-4bfc6b2e7a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

