### PR TITLE
Fix Filament mounted actions without name (Nightwatch nw-ref-30, #119)

### DIFF
--- a/app/Filament/MountedActionsSanitizer.php
+++ b/app/Filament/MountedActionsSanitizer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament;
+
+use Livewire\Component;
+
+class MountedActionsSanitizer
+{
+    public static function sanitizeComponent(Component $component): void
+    {
+        if (! property_exists($component, 'mountedActions')) {
+            return;
+        }
+
+        $mounted = $component->mountedActions;
+
+        if (! is_array($mounted) || $mounted === []) {
+            return;
+        }
+
+        $sanitized = [];
+
+        foreach ($mounted as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            if (! filled($entry['name'] ?? null)) {
+                continue;
+            }
+
+            $sanitized[] = $entry;
+        }
+
+        if (count($sanitized) !== count($mounted)) {
+            $component->mountedActions = $sanitized;
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace App\Providers;
 
+use App\Filament\MountedActionsSanitizer;
 use App\Policies\WebflowSitePolicy;
 use Filament\Support\Facades\FilamentTimezone;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\Query;
+use Livewire\Component;
+use Livewire\EventBus;
 use Positiv\FilamentWebflow\Models\WebflowSite;
 
 class AppServiceProvider extends ServiceProvider
@@ -25,6 +28,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $eventBus = $this->app->make(EventBus::class);
+
+        $eventBus->before('hydrate', function (Component $component): void {
+            MountedActionsSanitizer::sanitizeComponent($component);
+        });
+
+        $eventBus->before('dehydrate', function (Component $component): void {
+            MountedActionsSanitizer::sanitizeComponent($component);
+        });
+
         Gate::policy(WebflowSite::class, WebflowSitePolicy::class);
 
         config([

--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -244,10 +244,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public static function getSlug(?\Filament\Panel $panel = null): string

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -103,9 +103,9 @@ class WebflowItemEditPage extends Page
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/tests/Unit/MountedActionsSanitizerTest.php
+++ b/tests/Unit/MountedActionsSanitizerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Filament\MountedActionsSanitizer;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Livewire\Component;
+
+it('removes mounted action entries that are missing a name', function (): void {
+    $component = new class extends Component implements HasActions
+    {
+        use InteractsWithActions;
+    };
+
+    $component->mountedActions = [
+        ['data' => ['description' => ['type' => 'doc', 'content' => []]]],
+    ];
+
+    MountedActionsSanitizer::sanitizeComponent($component);
+
+    expect($component->mountedActions)->toBe([]);
+});
+
+it('keeps only entries that declare a non-blank name', function (): void {
+    $component = new class extends Component implements HasActions
+    {
+        use InteractsWithActions;
+    };
+
+    $component->mountedActions = [
+        ['data' => ['description' => ['type' => 'doc', 'content' => []]]],
+        ['name' => 'generateSkus', 'arguments' => [], 'context' => []],
+    ];
+
+    MountedActionsSanitizer::sanitizeComponent($component);
+
+    expect($component->mountedActions)->toHaveCount(1)
+        ->and($component->mountedActions[0]['name'] ?? null)->toBe('generateSkus');
+});
+
+it('does not modify components that do not expose mounted actions', function (): void {
+    $component = new class extends Component {};
+
+    MountedActionsSanitizer::sanitizeComponent($component);
+
+    expect(property_exists($component, 'mountedActions'))->toBeFalse();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks https://github.com/janiator/filament-pos-stripe/issues/119

**Nightwatch:** `nw-ref-30` (NW #30)

## Cause

Filament can persist entries on the Livewire `mountedActions` stack that contain serialized modal field `data` but **no `name`** (similar to upstream discussion in [filamentphp/filament#17096](https://github.com/filamentphp/filament/issues/17096)). On the next Livewire update, Filament calls `resolveActions()`, which throws `Filament\Actions\Exceptions\ActionNotResolvableException` with the message *An action tried to resolve without a name.* That exception is wrapped as `Illuminate\View\ViewException`, matching the Nightwatch report.

## Fix

- Add `App\Filament\MountedActionsSanitizer` and register Livewire `EventBus::before('hydrate')` and `before('dehydrate')` handlers in `AppServiceProvider` to remove invalid `mountedActions` rows (non-array entries or entries with a blank `name`) before Filament resolves the stack.
- Update `packages/filament-webflow` `Page::getUrl()` overrides (`WebflowCollectionItemsPage`, `WebflowItemEditPage`) to match the Filament v4 parent signature so PHP 8.4 can autoload these classes during `php artisan` / test bootstrap (same adjustment as in the nw-ref-34 hardening PR).

## How to verify

```bash
php artisan test --compact tests/Unit/MountedActionsSanitizerTest.php
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54d7881a-4d97-43c4-8d50-7548f7fbef07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54d7881a-4d97-43c4-8d50-7548f7fbef07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

