### PR TITLE
Honor DATABASE_URL for DB connections (Nightwatch nw-ref-36)

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -33,7 +33,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'url' => env('DB_URL'),
+            'url' => env('DB_URL') ?: env('DATABASE_URL'),
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
@@ -45,7 +45,7 @@ return [
 
         'mysql' => [
             'driver' => 'mysql',
-            'url' => env('DB_URL'),
+            'url' => env('DB_URL') ?: env('DATABASE_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'laravel'),
@@ -65,7 +65,7 @@ return [
 
         'mariadb' => [
             'driver' => 'mariadb',
-            'url' => env('DB_URL'),
+            'url' => env('DB_URL') ?: env('DATABASE_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'laravel'),
@@ -85,7 +85,7 @@ return [
 
         'pgsql' => [
             'driver' => 'pgsql',
-            'url' => env('DB_URL'),
+            'url' => env('DB_URL') ?: env('DATABASE_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'laravel'),
@@ -100,7 +100,7 @@ return [
 
         'sqlsrv' => [
             'driver' => 'sqlsrv',
-            'url' => env('DB_URL'),
+            'url' => env('DB_URL') ?: env('DATABASE_URL'),
             'host' => env('DB_HOST', 'localhost'),
             'port' => env('DB_PORT', '1433'),
             'database' => env('DB_DATABASE', 'laravel'),

--- a/tests/Unit/DatabaseUsesDatabaseUrlFallbackTest.php
+++ b/tests/Unit/DatabaseUsesDatabaseUrlFallbackTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\ConfigurationUrlParser;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Env;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class DatabaseUsesDatabaseUrlFallbackTest extends TestCase
+{
+    /**
+     * Load the real Laravel `config/database.php` with a functioning `database_path()`
+     * helper (Composer autoload wires Foundation helpers to the container).
+     */
+    private function bootstrapConfigLoading(): void
+    {
+        require_once dirname(__DIR__, 2).'/vendor/autoload.php';
+
+        if (! Container::getInstance() instanceof Application) {
+            new Application(dirname(__DIR__, 2));
+        }
+    }
+
+    private function resetEnvironmentRepository(): void
+    {
+        $reflection = new ReflectionClass(Env::class);
+        $reflection->getProperty('repository')->setValue(null, null);
+    }
+
+    /**
+     * @return array<string, array{hasEnv: bool, env: mixed, hasServer: bool, server: mixed, hasGetenv: bool, getenv: string|false}>
+     */
+    private function snapshotEnvironmentKeys(array $keys): array
+    {
+        $snapshot = [];
+
+        foreach ($keys as $key) {
+            $snapshot[$key] = [
+                'hasEnv' => array_key_exists($key, $_ENV),
+                'env' => $_ENV[$key] ?? null,
+                'hasServer' => array_key_exists($key, $_SERVER),
+                'server' => $_SERVER[$key] ?? null,
+                'hasGetenv' => getenv($key) !== false,
+                'getenv' => getenv($key),
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  array<string, array{hasEnv: bool, env: mixed, hasServer: bool, server: mixed, hasGetenv: bool, getenv: string|false}>  $snapshot
+     */
+    private function restoreEnvironmentSnapshot(array $snapshot): void
+    {
+        foreach ($snapshot as $key => $state) {
+            if ($state['hasEnv']) {
+                $_ENV[$key] = $state['env'];
+            } else {
+                unset($_ENV[$key]);
+            }
+
+            if ($state['hasServer']) {
+                $_SERVER[$key] = $state['server'];
+            } else {
+                unset($_SERVER[$key]);
+            }
+
+            if ($state['hasGetenv']) {
+                putenv($key.'='.$state['getenv']);
+            } else {
+                putenv($key);
+            }
+        }
+
+        $this->resetEnvironmentRepository();
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function test_postgres_connection_uses_database_url_when_db_url_missing(): void
+    {
+        $this->bootstrapConfigLoading();
+
+        $keys = ['DB_URL', 'DATABASE_URL'];
+        $snapshot = $this->snapshotEnvironmentKeys($keys);
+
+        try {
+            unset($_ENV['DB_URL'], $_SERVER['DB_URL']);
+            putenv('DB_URL');
+
+            $databaseUrl = 'postgres://user:secret@queue-db.invalid:5432/app';
+            $_ENV['DATABASE_URL'] = $databaseUrl;
+            $_SERVER['DATABASE_URL'] = $databaseUrl;
+            putenv('DATABASE_URL='.$databaseUrl);
+
+            $this->resetEnvironmentRepository();
+
+            /** @var array $database */
+            $database = require dirname(__DIR__, 2).'/config/database.php';
+            $config = $database['connections']['pgsql'];
+            $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
+
+            $this->assertSame('queue-db.invalid', $parsed['host']);
+            $this->assertSame('5432', (string) $parsed['port']);
+        } finally {
+            $this->restoreEnvironmentSnapshot($snapshot);
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function test_postgres_connection_prefers_db_url_over_database_url(): void
+    {
+        $this->bootstrapConfigLoading();
+
+        $keys = ['DB_URL', 'DATABASE_URL'];
+        $snapshot = $this->snapshotEnvironmentKeys($keys);
+
+        try {
+            $primary = 'postgres://a:a@primary.invalid:5432/db';
+            $secondary = 'postgres://b:b@secondary.invalid:5432/db';
+
+            $_ENV['DB_URL'] = $primary;
+            $_SERVER['DB_URL'] = $primary;
+            putenv('DB_URL='.$primary);
+
+            $_ENV['DATABASE_URL'] = $secondary;
+            $_SERVER['DATABASE_URL'] = $secondary;
+            putenv('DATABASE_URL='.$secondary);
+
+            $this->resetEnvironmentRepository();
+
+            /** @var array $database */
+            $database = require dirname(__DIR__, 2).'/config/database.php';
+            $config = $database['connections']['pgsql'];
+            $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
+
+            $this->assertSame('primary.invalid', $parsed['host']);
+        } finally {
+            $this->restoreEnvironmentSnapshot($snapshot);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes PostgreSQL **`QueryException: connection … 127.0.0.1:5432 refused`** raised for queue/Horizon workers (**Nightwatch** ref **nw-ref-36** / GitHub **https://github.com/janiator/filament-pos-stripe/issues/121**).

### Cause

Many Postgres providers inject **`DATABASE_URL`**, while Laravel’s published config referenced **`DB_URL`** only for the **`url`** configuration key. Without **`DB_URL`** (and frequently without **`DB_HOST`** in supervisor/systemd environments), Laravel kept the default **`host`** of **`127.0.0.1`**, so workers attempted a local Postgres socket rather than the host embedded in **`DATABASE_URL`**.

### Fix

For every connection in **`config/database.php`**, configure **`'url' => env('DB_URL') ?: env('DATABASE_URL')`**. Laravel’s **`ConfigurationUrlParser`** merges parsed URL components ahead of placeholders, yielding the correct host/port for Postgres (and parity for other drivers that share the same URL pattern).

### How to verify

Run the focused PHPUnit case that loads **`config/database.php`** and parses the **`pgsql`** DSN via the framework resolver:

```
vendor/bin/phpunit tests/Unit/DatabaseUsesDatabaseUrlFallbackTest.php --colors=never
```

Staging check: provision workers with **`DATABASE_URL`** only (no **`DB_URL`**) and enqueue a **`database`** queue driver job; it must connect successfully without looping back to **`127.0.0.1`**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-277b474f-99f2-494f-a44d-cd3eee09f8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-277b474f-99f2-494f-a44d-cd3eee09f8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

