### PR TITLE
fix(Stripe): omit unit_label for non-service products on create (nw-ref-15)

### DIFF
--- a/app/Actions/ConnectedProducts/CreateConnectedProductInStripe.php
+++ b/app/Actions/ConnectedProducts/CreateConnectedProductInStripe.php
@@ -74,7 +74,12 @@ class CreateConnectedProductInStripe
                 $createData['tax_code'] = $product->tax_code;
             }
 
-            if ($product->unit_label !== null) {
+            $stripeProductType = $product->type ?? 'service';
+            if (
+                is_string($stripeProductType)
+                && strtolower($stripeProductType) === 'service'
+                && $product->unit_label !== null
+            ) {
                 $createData['unit_label'] = $product->unit_label;
             }
 

--- a/tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripeTest.php
+++ b/tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Actions\ConnectedProducts\CreateConnectedProductInStripe;
+use App\Models\ConnectedProduct;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lanos\CashierConnect\Models\ConnectMapping;
+use Stripe\StripeClient;
+
+uses(RefreshDatabase::class);
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('omits unit_label from Stripe product create payload when type is good', function () {
+    config()->set('cashier.secret', null);
+    config()->set('services.stripe.secret', 'sk_test_create_unit_label_good');
+
+    $store = Store::factory()->create([
+        'stripe_account_id' => 'acct_test_create_unit_label_good',
+    ]);
+
+    ConnectMapping::query()->create([
+        'model' => Store::class,
+        'model_id' => $store->id,
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'standard',
+    ]);
+
+    $product = ConnectedProduct::withoutEvents(fn () => ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'good',
+        'unit_label' => 'kg',
+        'name' => 'Weighted Good',
+    ]));
+
+    expect($store->fresh()->hasStripeAccount())->toBeTrue();
+
+    $mockStripe = Mockery::mock('alias:'.StripeClient::class);
+    $mockProducts = Mockery::mock();
+    $mockStripe->shouldReceive('__construct')->once()->andReturnSelf();
+    $mockStripe->products = $mockProducts;
+
+    $mockProducts->shouldReceive('create')
+        ->once()
+        ->with(
+            Mockery::on(fn (array $data): bool => ($data['type'] ?? null) === 'good'
+                && ! array_key_exists('unit_label', $data)
+                && ($data['name'] ?? null) === 'Weighted Good'
+            ),
+            ['stripe_account' => $store->stripe_account_id]
+        )
+        ->andReturn((object) ['id' => 'prod_create_good_1']);
+
+    $action = new CreateConnectedProductInStripe;
+    $result = $action($product);
+
+    expect($result)->toBe('prod_create_good_1');
+});
+
+it('includes unit_label on Stripe product create when type is service', function () {
+    config()->set('cashier.secret', null);
+    config()->set('services.stripe.secret', 'sk_test_create_unit_label_service');
+
+    $store = Store::factory()->create([
+        'stripe_account_id' => 'acct_test_create_unit_label_service',
+    ]);
+
+    ConnectMapping::query()->create([
+        'model' => Store::class,
+        'model_id' => $store->id,
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'standard',
+    ]);
+
+    $product = ConnectedProduct::withoutEvents(fn () => ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'service',
+        'unit_label' => 'hour',
+        'name' => 'Consulting',
+    ]));
+
+    expect($store->fresh()->hasStripeAccount())->toBeTrue();
+
+    $mockStripe = Mockery::mock('alias:'.StripeClient::class);
+    $mockProducts = Mockery::mock();
+    $mockStripe->shouldReceive('__construct')->once()->andReturnSelf();
+    $mockStripe->products = $mockProducts;
+
+    $mockProducts->shouldReceive('create')
+        ->once()
+        ->with(
+            Mockery::on(fn (array $data): bool => ($data['type'] ?? null) === 'service'
+                && ($data['unit_label'] ?? null) === 'hour'
+                && ($data['name'] ?? null) === 'Consulting'
+            ),
+            ['stripe_account' => $store->stripe_account_id]
+        )
+        ->andReturn((object) ['id' => 'prod_create_service_1']);
+
+    $action = new CreateConnectedProductInStripe;
+    $result = $action($product);
+
+    expect($result)->toBe('prod_create_service_1');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/janiator/filament-pos-stripe/issues/123 (Nightwatch **nw-ref-15** / ref #15).

## Cause

The Stripe API only allows `unit_label` on **service** products. `UpdateConnectedProductToStripe` already sent `unit_label` only when `type === 'service'`, but `CreateConnectedProductInStripe` forwarded `unit_label` whenever it was set on the connected product, including for `good` (and other non-service) types. That triggered Stripe exceptions during product create on Connect accounts.

## Fix

Gate `unit_label` in `CreateConnectedProductInStripe` the same way as updates: include it only when the resolved product type is `service` (using `type ?? 'service'` so the default create type stays consistent) and `unit_label` is non-null.

## How to verify

```bash
php artisan test --compact tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripeTest.php tests/Feature/Actions/ConnectedProducts/UpdateConnectedProductToStripeTest.php
```

The new tests mock `StripeClient` and assert the create payload omits `unit_label` for `good` products and includes it for `service` products.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1330b901-940b-42d5-986c-6cec2b4677eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1330b901-940b-42d5-986c-6cec2b4677eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

