### PR TITLE
Fix Stripe unit_label on product create for non-service types (Nightwatch nw-ref-18)

### DIFF
--- a/app/Actions/ConnectedProducts/CreateConnectedProductInStripe.php
+++ b/app/Actions/ConnectedProducts/CreateConnectedProductInStripe.php
@@ -74,7 +74,12 @@ class CreateConnectedProductInStripe
                 $createData['tax_code'] = $product->tax_code;
             }
 
-            if ($product->unit_label !== null) {
+            $stripeProductType = $product->type ?? 'service';
+            if (
+                is_string($stripeProductType)
+                && strtolower($stripeProductType) === 'service'
+                && $product->unit_label !== null
+            ) {
                 $createData['unit_label'] = $product->unit_label;
             }
 

--- a/tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripeTest.php
+++ b/tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Actions\ConnectedProducts\CreateConnectedProductInStripe;
+use App\Models\ConnectedProduct;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lanos\CashierConnect\Models\ConnectMapping;
+use Stripe\StripeClient;
+
+uses(RefreshDatabase::class);
+
+afterEach(function () {
+    \Mockery::close();
+});
+
+it('omits unit_label for non-service products and includes it for service products', function () {
+    config()->set('services.stripe.secret', 'sk_test_create_unit_label');
+
+    $mockStripe = \Mockery::mock('alias:'.StripeClient::class);
+    $mockProducts = \Mockery::mock();
+    $mockStripe->shouldReceive('__construct')->andReturnSelf();
+    $mockStripe->products = $mockProducts;
+
+    $store = Store::factory()->create([
+        'stripe_account_id' => 'acct_test_create_unit_label',
+    ]);
+
+    ConnectMapping::query()->create([
+        'model' => Store::class,
+        'model_id' => $store->id,
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'standard',
+    ]);
+
+    expect($store->fresh()->hasStripeAccount())->toBeTrue();
+
+    $captures = [];
+
+    $mockProducts->shouldReceive('create')
+        ->twice()
+        ->withArgs(function (array $data, array $opts) use (&$captures, $store) {
+            $captures[] = $data;
+
+            return ($opts['stripe_account'] ?? null) === $store->stripe_account_id;
+        })
+        ->andReturn((object) ['id' => 'prod_created_test']);
+
+    $goodProduct = ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'good',
+        'unit_label' => 'kg',
+    ]);
+
+    $serviceProduct = ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'service',
+        'unit_label' => 'hour',
+    ]);
+
+    $action = new CreateConnectedProductInStripe;
+
+    $action($goodProduct);
+    $action($serviceProduct);
+
+    expect($captures)->toHaveCount(2)
+        ->and($captures[0])->not->toHaveKey('unit_label')
+        ->and($captures[0]['type'])->toBe('good')
+        ->and($captures[1])->toHaveKey('unit_label')
+        ->and($captures[1]['unit_label'])->toBe('hour')
+        ->and($captures[1]['type'])->toBe('service');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/janiator/filament-pos-stripe/issues/125 (Nightwatch **nw-ref-18** / ref #18).

**Cause:** `CreateConnectedProductInStripe` always sent `unit_label` in the Products API create payload whenever the local model had `unit_label` set. Stripe only allows `unit_label` for **service** products (`type: service`), not for **good** products. That mismatch matches the earlier issue #15 pattern: updates were already guarded in `UpdateConnectedProductToStripe`, but creates were not.

**Fix:** Only add `unit_label` to the create payload when the effective product type is service (using the same `?? 'service'` default as the `type` field sent to Stripe, case-insensitive). Physical goods with a quantity unit / label in the app no longer trigger an API error on create.

**How to verify:** Run the focused tests (and confirm create sync for a `good` product with `unit_label` no longer fails against Stripe):

```bash
php artisan test --compact tests/Feature/Actions/ConnectedProducts/CreateConnectedProductInStripeTest.php tests/Feature/Actions/ConnectedProducts/UpdateConnectedProductToStripeTest.php
```

The new test mocks `StripeClient` and asserts the create payload omits `unit_label` for `type: good` and includes it for `type: service`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45b87a74-136d-404f-9a05-b1064e9099d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45b87a74-136d-404f-9a05-b1064e9099d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

