### PR TITLE
fix(Filament): guard POS purchases cashier filter when user_id missing (Nightwatch #17)

### DIFF
--- a/app/Filament/Resources/PosPurchases/Tables/PosPurchasesTable.php
+++ b/app/Filament/Resources/PosPurchases/Tables/PosPurchasesTable.php
@@ -181,11 +181,13 @@ class PosPurchasesTable
                             ->placeholder(__('All')),
                     ])
                     ->query(function (Builder $query, array $data): Builder {
+                        $userId = $data['user_id'] ?? null;
+
                         return $query->when(
-                            filled($data['user_id']),
+                            filled($userId),
                             fn (Builder $query): Builder => $query->whereHas(
                                 'posSession',
-                                fn (Builder $q) => $q->where('user_id', $data['user_id']),
+                                fn (Builder $q) => $q->where('user_id', $userId),
                             ),
                         );
                     }),

--- a/tests/Feature/PosPurchasesListPageTest.php
+++ b/tests/Feature/PosPurchasesListPageTest.php
@@ -44,6 +44,12 @@ it('can load the POS purchases list page', function () {
         ->assertOk();
 });
 
+it('does not throw when the cashier table filter omits user_id in form data', function () {
+    livewire(ListPosPurchases::class)
+        ->filterTable('cashier', [])
+        ->assertOk();
+});
+
 it('can filter POS purchases by status', function () {
     $session = PosSession::factory()->create([
         'store_id' => $this->store->id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the production exception tracked in https://github.com/janiator/filament-pos-stripe/issues/127 (Laravel Nightwatch **nw-ref-17**, Nightwatch ref **#17**).

## Cause

On the POS purchases Filament list, the custom **Cashier** table filter (`Filter::make('cashier')`) builds query constraints from filter form state (`$data`). When that array does not include a `user_id` key (for example after applying the filter with empty form data), PHP 8+ throws **Undefined array key `user_id`** inside the filter `query()` callback— surfacing as a `ViewException` on the table index.

## Fix

Read a safe value with `$userId = $data['user_id'] ?? null` and use `filled($userId)` and `where('user_id', $userId)` so missing keys are handled like an unset cashier selection.

## How to verify

```bash
php artisan test --compact tests/Feature/PosPurchasesListPageTest.php --filter="cashier"
```

The new test applies `filterTable('cashier', [])` on `ListPosPurchases`, which previously exercised the failing code path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5ec1a72-4b68-4e2a-a0eb-79f73af42b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5ec1a72-4b68-4e2a-a0eb-79f73af42b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

