### PR TITLE
fix(webflow): tenant-scope Webflow CMS by site store_id (closes Nightwatch nw-ref-12 / #129)

### DIFF
--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -52,7 +52,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         $collectionId = (int) $this->collection;
         $this->collectionModel = WebflowCollection::where('id', $collectionId)
             ->where('is_active', true)
-            ->whereHas('site', fn ($q) => $tenant ? $q->where('store_id', $tenant->getKey()) : $q)
+            ->forSiteOnStore($tenant?->getKey())
             ->firstOrFail();
     }
 
@@ -61,7 +61,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         // Redirect to first available collection or Webflow Sites
         $tenant = Filament::getTenant();
         $first = WebflowCollection::where('is_active', true)
-            ->whereHas('site', fn ($q) => $tenant ? $q->where('store_id', $tenant->getKey()) : $q)
+            ->forSiteOnStore($tenant?->getKey())
             ->first();
         if ($first) {
             $this->collection = $first->id;
@@ -244,10 +244,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public static function getSlug(?\Filament\Panel $panel = null): string

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -83,7 +83,7 @@ class WebflowItemEditPage extends Page
             ->where('id', $this->itemId)
             ->whereHas('collection', function ($q) use ($tenant) {
                 $q->where('is_active', true)
-                    ->whereHas('site', fn ($q2) => $tenant ? $q2->where('store_id', $tenant->getKey()) : $q2);
+                    ->forSiteOnStore($tenant?->getKey());
             })
             ->first();
     }
@@ -103,9 +103,9 @@ class WebflowItemEditPage extends Page
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/packages/filament-webflow/src/Filament/Resources/WebflowSiteResource/RelationManagers/CollectionsRelationManager.php
+++ b/packages/filament-webflow/src/Filament/Resources/WebflowSiteResource/RelationManagers/CollectionsRelationManager.php
@@ -124,7 +124,7 @@ class CollectionsRelationManager extends RelationManager
                     ->action(function (array $data, WebflowCollection $record): void {
                         $storeId = $this->getOwnerRecord()->store_id;
                         WebflowCollection::query()
-                            ->whereHas('site', fn ($q) => $q->where('store_id', $storeId))
+                            ->forSiteOnStore($storeId)
                             ->where('id', '!=', $record->id)
                             ->update(['use_for_event_tickets' => false]);
                         $record->update([

--- a/packages/filament-webflow/src/Models/WebflowCollection.php
+++ b/packages/filament-webflow/src/Models/WebflowCollection.php
@@ -2,6 +2,7 @@
 
 namespace Positiv\FilamentWebflow\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -38,5 +39,26 @@ class WebflowCollection extends Model
     public function items(): HasMany
     {
         return $this->hasMany(WebflowItem::class, 'webflow_collection_id');
+    }
+
+    /**
+     * Limits collections whose Webflow site belongs to the given store.
+     *
+     * Tenant access uses {@see WebflowSite::$store_id} directly; legacy addon-based linkage
+     * was removed in favor of the {@see WebflowSite::store()} relation.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForSiteOnStore(Builder $query, int|string|null $storeKey): Builder
+    {
+        if ($storeKey === null || $storeKey === '') {
+            return $query;
+        }
+
+        return $query->whereHas(
+            'site',
+            fn (Builder $siteQuery): Builder => $siteQuery->where('store_id', $storeKey),
+        );
     }
 }

--- a/tests/Feature/Webflow/WebflowCollectionForSiteOnStoreScopeTest.php
+++ b/tests/Feature/Webflow/WebflowCollectionForSiteOnStoreScopeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Positiv\FilamentWebflow\Models\WebflowCollection;
+use Positiv\FilamentWebflow\Models\WebflowSite;
+
+uses(RefreshDatabase::class)->group('webflow');
+
+it('scopes webflow collections via webflow site store_id without an addon relation on WebflowSite', function (): void {
+    expect(method_exists(WebflowSite::class, 'addon'))->toBeFalse();
+
+    $storeA = Store::factory()->create();
+    $storeB = Store::factory()->create();
+
+    $siteA = WebflowSite::create([
+        'store_id' => $storeA->id,
+        'webflow_site_id' => 'webflow_a_'.uniqid(),
+        'name' => 'Site A',
+        'is_active' => true,
+    ]);
+    $siteB = WebflowSite::create([
+        'store_id' => $storeB->id,
+        'webflow_site_id' => 'webflow_b_'.uniqid(),
+        'name' => 'Site B',
+        'is_active' => true,
+    ]);
+
+    $collectionForA = WebflowCollection::create([
+        'webflow_site_id' => $siteA->id,
+        'webflow_collection_id' => 'col_a_'.uniqid(),
+        'name' => 'Collection A',
+        'is_active' => true,
+    ]);
+    WebflowCollection::create([
+        'webflow_site_id' => $siteB->id,
+        'webflow_collection_id' => 'col_b_'.uniqid(),
+        'name' => 'Collection B',
+        'is_active' => true,
+    ]);
+
+    $scoped = WebflowCollection::query()->forSiteOnStore($storeA->id)->pluck('id')->all();
+
+    expect($scoped)->toContain($collectionForA->id)->and($scoped)->toHaveCount(1);
+});
+
+it('does not filter by store when the store key for scopeForSiteOnStore is null', function (): void {
+    $store = Store::factory()->create();
+    $site = WebflowSite::create([
+        'store_id' => $store->id,
+        'webflow_site_id' => 'webflow_'.uniqid(),
+        'name' => 'Only site',
+        'is_active' => true,
+    ]);
+    WebflowCollection::create([
+        'webflow_site_id' => $site->id,
+        'webflow_collection_id' => 'col_'.uniqid(),
+        'name' => 'Collection',
+        'is_active' => true,
+    ]);
+
+    expect(WebflowCollection::query()->forSiteOnStore(null)->count())->toBe(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Tracks

- Closes GitHub [#129](https://github.com/janiator/filament-pos-stripe/issues/129) (Nightwatch **nw-ref-12**, ref **NW #12**).

## Cause

`webflow_sites` were migrated off `addon_id` to **`store_id`**, and **`WebflowSite::addon()`** was removed from the domain model. Some queries still chained **nested `site.addon` / `whereHas('addon', …)`** style relationships (historically reproduced as `BadMethodCallException` for `addon()`—Nightwatch surfaced this as affecting Filament Webflow/CMS flows tied to tenancy). The correction is **always tie tenant access to `WebflowSite.store_id`** (the `store()` relation), not an addon linkage.

## Fix

- **`WebflowCollection::forSiteOnStore()`** centralizes filtering collections whose parent site belongs to the current tenant store.
- **Filament surfaces** (`WebflowCollectionItemsPage`, `WebflowItemEditPage`, `CollectionsRelationManager`) now call that scope instead of ad-hoc `whereHas('site', …)` only (same behavior, clearer API aligned with **`store_id`**).
- **`getUrl(...)` overrides** on the package `Page` classes forward Filament **v4.5**’s `$shouldGuessMissingParameters` / `$configuration` parameters so Laravel can bootstrap without a fatal signature mismatch.

## Verification

```bash
DB_CONNECTION=pgsql DB_HOST=127.0.0.1 DB_DATABASE=pos_stripe_test DB_USERNAME=postgres DB_PASSWORD=postgres \
  php artisan test --compact tests/Feature/Webflow/WebflowCollectionForSiteOnStoreScopeTest.php
```

(Adjust credentials to match your test database; PHPUnit’s `postgres`/`pos_stripe_test` setup is unchanged.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a21ee91-d134-484e-a868-ebb7a97686b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a21ee91-d134-484e-a868-ebb7a97686b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

