### PR TITLE
fix(webflow): WebflowSite tenant scope without addon() (Nightwatch nw-ref-11 / #131)

### DIFF
--- a/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowCollectionItemsPage.php
@@ -52,7 +52,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         $collectionId = (int) $this->collection;
         $this->collectionModel = WebflowCollection::where('id', $collectionId)
             ->where('is_active', true)
-            ->whereHas('site', fn ($q) => $tenant ? $q->where('store_id', $tenant->getKey()) : $q)
+            ->forSiteOnStore($tenant?->getKey())
             ->firstOrFail();
     }
 
@@ -61,7 +61,7 @@ class WebflowCollectionItemsPage extends Page implements HasTable
         // Redirect to first available collection or Webflow Sites
         $tenant = Filament::getTenant();
         $first = WebflowCollection::where('is_active', true)
-            ->whereHas('site', fn ($q) => $tenant ? $q->where('store_id', $tenant->getKey()) : $q)
+            ->forSiteOnStore($tenant?->getKey())
             ->first();
         if ($first) {
             $this->collection = $first->id;
@@ -244,10 +244,10 @@ class WebflowCollectionItemsPage extends Page implements HasTable
             });
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
         // Parent already adds extra parameters (e.g. collection) as query string; do not append again
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public static function getSlug(?\Filament\Panel $panel = null): string

--- a/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
+++ b/packages/filament-webflow/src/Filament/Pages/WebflowItemEditPage.php
@@ -83,7 +83,7 @@ class WebflowItemEditPage extends Page
             ->where('id', $this->itemId)
             ->whereHas('collection', function ($q) use ($tenant) {
                 $q->where('is_active', true)
-                    ->whereHas('site', fn ($q2) => $tenant ? $q2->where('store_id', $tenant->getKey()) : $q2);
+                    ->forSiteOnStore($tenant?->getKey());
             })
             ->first();
     }
@@ -103,9 +103,9 @@ class WebflowItemEditPage extends Page
         return 'webflow-cms-items/{item}/edit';
     }
 
-    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null): string
+    public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?\Illuminate\Database\Eloquent\Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant);
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public function form(Schema $schema): Schema

--- a/packages/filament-webflow/src/Filament/Resources/WebflowSiteResource/RelationManagers/CollectionsRelationManager.php
+++ b/packages/filament-webflow/src/Filament/Resources/WebflowSiteResource/RelationManagers/CollectionsRelationManager.php
@@ -124,7 +124,7 @@ class CollectionsRelationManager extends RelationManager
                     ->action(function (array $data, WebflowCollection $record): void {
                         $storeId = $this->getOwnerRecord()->store_id;
                         WebflowCollection::query()
-                            ->whereHas('site', fn ($q) => $q->where('store_id', $storeId))
+                            ->forSiteOnStore($storeId)
                             ->where('id', '!=', $record->id)
                             ->update(['use_for_event_tickets' => false]);
                         $record->update([

--- a/packages/filament-webflow/src/Models/WebflowCollection.php
+++ b/packages/filament-webflow/src/Models/WebflowCollection.php
@@ -2,6 +2,7 @@
 
 namespace Positiv\FilamentWebflow\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -38,5 +39,26 @@ class WebflowCollection extends Model
     public function items(): HasMany
     {
         return $this->hasMany(WebflowItem::class, 'webflow_collection_id');
+    }
+
+    /**
+     * Limit collections whose Webflow site belongs to the given store (tenant).
+     *
+     * Webflow sites are scoped by {@see WebflowSite::$store_id}; legacy per-addon linkage on
+     * the site record was removed in favor of {@see WebflowSite::store()}.
+     *
+     * @param  Builder<WebflowCollection>  $query
+     * @return Builder<WebflowCollection>
+     */
+    public function scopeForSiteOnStore(Builder $query, int|string|null $storeKey): Builder
+    {
+        if ($storeKey === null || $storeKey === '') {
+            return $query;
+        }
+
+        return $query->whereHas(
+            'site',
+            fn (Builder $siteQuery): Builder => $siteQuery->where('store_id', $storeKey),
+        );
     }
 }

--- a/tests/Feature/Webflow/WebflowCollectionForSiteOnStoreScopeTest.php
+++ b/tests/Feature/Webflow/WebflowCollectionForSiteOnStoreScopeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Positiv\FilamentWebflow\Models\WebflowCollection;
+use Positiv\FilamentWebflow\Models\WebflowSite;
+
+uses()->group('webflow');
+
+it('does not define WebflowSite::addon and scopes collections via site store_id in SQL', function (): void {
+    expect(method_exists(WebflowSite::class, 'addon'))->toBeFalse();
+
+    $sql = WebflowCollection::query()->forSiteOnStore(42)->toSql();
+
+    expect($sql)
+        ->toContain('store_id')
+        ->toContain('webflow_sites');
+});
+
+it('does not add tenant constraint when forSiteOnStore receives null or empty string', function (): void {
+    expect(WebflowCollection::query()->forSiteOnStore(null)->toSql())
+        ->toBe('select * from "webflow_collections"');
+
+    expect(WebflowCollection::query()->forSiteOnStore('')->toSql())
+        ->toBe('select * from "webflow_collections"');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks GitHub issue [#131](https://github.com/janiator/filament-pos-stripe/issues/131) (Nightwatch **nw-ref-11** / **NW #11**).

## Cause

`webflow_sites` were moved from `addon_id` to **`store_id`**, and **`WebflowSite::addon()`** was removed from the model. Filament Webflow CMS code paths must scope data by the site’s **`store_id`** (via `WebflowSite::store()`), not by an addon relation. Nightwatch reported `BadMethodCallException: WebflowSite::addon()` (same class of failure as nw-ref-12 / [#129](https://github.com/janiator/filament-pos-stripe/issues/129)).

## Fix

- Add **`WebflowCollection::forSiteOnStore()`** to centralize “collection → site → `store_id`” tenant filtering.
- Use that scope on **Webflow collection items**, **Webflow item edit resolve**, and **collections relation manager** (replacing ad-hoc `whereHas('site', …)`).
- Align **`getUrl()`** overrides on package `Page` classes with Filament v4.5’s extra parameters so calls to `parent::getUrl()` stay compatible.

## How to verify

```bash
php artisan test --compact tests/Feature/Webflow/WebflowCollectionForSiteOnStoreScopeTest.php
```

With the project’s usual Postgres test DB (`phpunit.xml`), the full feature suite can also be run as needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32a92268-4df5-470b-967f-898bf07fc03e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32a92268-4df5-470b-967f-898bf07fc03e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

