### PR TITLE
Fix NW #10: null-callable Tripletex voucher preview toggle

### DIFF
--- a/app/Filament/Actions/TripletexVoucherPreviewAction.php
+++ b/app/Filament/Actions/TripletexVoucherPreviewAction.php
@@ -9,6 +9,7 @@ use App\Models\StoreStripePayout;
 use App\Services\Tripletex\TripletexSyncPreviewService;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Toggle;
@@ -37,17 +38,7 @@ final class TripletexVoucherPreviewAction
                 'resolve_tripletex_accounts' => false,
                 'preview_json' => self::encodeZReportPreview($record, false),
             ])
-            ->form(self::previewFormSchema(
-                resolveUsing: function (bool $resolve, Get $get): string {
-                    $id = (int) $get('_record_id');
-                    $session = PosSession::query()->find($id);
-                    if (! $session instanceof PosSession) {
-                        return json_encode(['ok' => false, 'error' => 'Session not found.'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-                    }
-
-                    return self::encodeZReportPreview($session, $resolve);
-                },
-            ))
+            ->form(self::zReportPreviewFormSchema())
             ->modalSubmitAction(false)
             ->modalCancelActionLabel('Close');
     }
@@ -68,26 +59,15 @@ final class TripletexVoucherPreviewAction
                 'resolve_tripletex_accounts' => false,
                 'preview_json' => self::encodePayoutPreview($record, false),
             ])
-            ->form(self::previewFormSchema(
-                resolveUsing: function (bool $resolve, Get $get): string {
-                    $id = (int) $get('_record_id');
-                    $payout = StoreStripePayout::query()->find($id);
-                    if (! $payout instanceof StoreStripePayout) {
-                        return json_encode(['ok' => false, 'error' => 'Payout not found.'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-                    }
-
-                    return self::encodePayoutPreview($payout, $resolve);
-                },
-            ))
+            ->form(self::payoutPreviewFormSchema())
             ->modalSubmitAction(false)
             ->modalCancelActionLabel('Close');
     }
 
     /**
-     * @param  callable(bool $resolve, Get $get): string  $resolveUsing
-     * @return list<\Filament\Forms\Components\Component>
+     * @return list<Component>
      */
-    protected static function previewFormSchema(callable $resolveUsing): array
+    protected static function zReportPreviewFormSchema(): array
     {
         return [
             Hidden::make('_record_id'),
@@ -96,9 +76,11 @@ final class TripletexVoucherPreviewAction
                 ->helperText(__('Creates a short-lived session token and resolves each ledger account number used in the voucher.'))
                 ->default(false)
                 ->live()
-                ->afterStateUpdated(function ($state, Set $set, Get $get) use ($resolveUsing): void {
-                    $json = $resolveUsing((bool) $state, $get);
-                    $set('preview_json', $json);
+                ->afterStateUpdated(function ($state, Set $set, Get $get): void {
+                    $set(
+                        'preview_json',
+                        self::resolveJsonForZReportPreview($get, (bool) $state),
+                    );
                 }),
             Textarea::make('preview_json')
                 ->label(__('Preview JSON'))
@@ -107,6 +89,55 @@ final class TripletexVoucherPreviewAction
                 ->columnSpanFull()
                 ->extraInputAttributes(['class' => 'font-mono text-xs']),
         ];
+    }
+
+    /**
+     * @return list<Component>
+     */
+    protected static function payoutPreviewFormSchema(): array
+    {
+        return [
+            Hidden::make('_record_id'),
+            Toggle::make('resolve_tripletex_accounts')
+                ->label(__('Resolve Tripletex account IDs (calls Tripletex API)'))
+                ->helperText(__('Creates a short-lived session token and resolves each ledger account number used in the voucher.'))
+                ->default(false)
+                ->live()
+                ->afterStateUpdated(function ($state, Set $set, Get $get): void {
+                    $set(
+                        'preview_json',
+                        self::resolveJsonForPayoutPreview($get, (bool) $state),
+                    );
+                }),
+            Textarea::make('preview_json')
+                ->label(__('Preview JSON'))
+                ->rows(28)
+                ->readOnly()
+                ->columnSpanFull()
+                ->extraInputAttributes(['class' => 'font-mono text-xs']),
+        ];
+    }
+
+    protected static function resolveJsonForZReportPreview(Get $get, bool $resolve): string
+    {
+        $id = (int) $get('_record_id');
+        $session = PosSession::query()->find($id);
+        if (! $session instanceof PosSession) {
+            return json_encode(['ok' => false, 'error' => 'Session not found.'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        return self::encodeZReportPreview($session, $resolve);
+    }
+
+    protected static function resolveJsonForPayoutPreview(Get $get, bool $resolve): string
+    {
+        $id = (int) $get('_record_id');
+        $payout = StoreStripePayout::query()->find($id);
+        if (! $payout instanceof StoreStripePayout) {
+            return json_encode(['ok' => false, 'error' => 'Payout not found.'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        return self::encodePayoutPreview($payout, $resolve);
     }
 
     public static function canPreviewZReport(PosSession $record): bool

--- a/tests/Unit/Filament/TripletexVoucherPreviewActionTest.php
+++ b/tests/Unit/Filament/TripletexVoucherPreviewActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Filament\Actions\TripletexVoucherPreviewAction;
+use Filament\Schemas\Components\Utilities\Get;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('resolveJsonForZReportPreview returns session not found when record id resolves empty', function (): void {
+    $get = Mockery::mock(Get::class);
+    $get->allows('__invoke')->with('_record_id')->andReturn(0);
+
+    $method = new ReflectionMethod(TripletexVoucherPreviewAction::class, 'resolveJsonForZReportPreview');
+    expect($method->isStatic())->toBeTrue();
+    $method->setAccessible(true);
+
+    $json = $method->invoke(null, $get, false);
+    $data = json_decode((string) $json, true, 512, JSON_THROW_ON_ERROR);
+
+    expect($data['ok'])->toBeFalse()
+        ->and($data['error'])->toBe('Session not found.');
+});
+
+it('resolveJsonForPayoutPreview returns payout not found when record id resolves empty', function (): void {
+    $get = Mockery::mock(Get::class);
+    $get->allows('__invoke')->with('_record_id')->andReturn(0);
+
+    $method = new ReflectionMethod(TripletexVoucherPreviewAction::class, 'resolveJsonForPayoutPreview');
+    $method->setAccessible(true);
+
+    $json = $method->invoke(null, $get, false);
+    $data = json_decode((string) $json, true, 512, JSON_THROW_ON_ERROR);
+
+    expect($data['ok'])->toBeFalse()
+        ->and($data['error'])->toBe('Payout not found.');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracked in [#133](https://github.com/janiator/filament-pos-stripe/issues/133).

**Nightwatch:** [NW #10](https://github.com/janiator/filament-pos-stripe/issues/133) / `nw-ref-10`.

### Cause

The Tripletex voucher preview slide-over used `->afterStateUpdated()` with `use ($resolveUsing)` capturing a Closure. During Livewire’s serialization lifecycle for modal form state updates, that bound callable can become `null`. PHP then evaluates `$resolveUsing(...)` as “invoke null”, which raises **Value of type null is not callable** when merchants toggle **Resolve Tripletex account IDs** on preview.

### Fix

Remove the serialized nested Closure. The reactive toggle now invokes **static helpers** [`resolveJsonForZReportPreview`](app/Filament/Actions/TripletexVoucherPreviewAction.php) and [`resolveJsonForPayoutPreview`](app/Filament/Actions/TripletexVoucherPreviewAction.php), which load the `_record_id` via Filament `Get`, build the preview JSON via the existing `encode*` methods.

### How to verify

1. Open a POS session row or Stripe payout row (Tripletex action visible), open **Preview Tripletex voucher**.
2. Toggle **Resolve Tripletex account IDs (calls Tripletex API)** on and off; the textarea should refresh without throwing the above exception.

**Automated tests:** [`tests/Unit/Filament/TripletexVoucherPreviewActionTest.php`](tests/Unit/Filament/TripletexVoucherPreviewActionTest.php) covers the static JSON resolution paths (`Session not found` / `Payout not found`). If local `php artisan test` exits early, check for an unrelated bootstrap fatal in `packages/filament-webflow` `Page::getUrl` compatibility with Filament before re-running those tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec60318-4fb1-429f-9885-b03e878c6ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec60318-4fb1-429f-9885-b03e878c6ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

