### PR TITLE
Fix Nightwatch nw-ref-7: SyncStoreCustomersFromStripeJob Bus batch contract

### DIFF
--- a/app/Jobs/SyncStoreCustomersFromStripeJob.php
+++ b/app/Jobs/SyncStoreCustomersFromStripeJob.php
@@ -10,8 +10,15 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Syncs Stripe customers for a single store.
+ *
+ * Uses {@see Batchable} because {@see SyncEverythingFromStripeJob} and {@see SyncStoreEverythingFromStripeJob}
+ * enqueue instances via {@see Bus::batch()}.
+ */
 class SyncStoreCustomersFromStripeJob implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

--- a/tests/Unit/Jobs/SyncStoreCustomersFromStripeJobBatchableTest.php
+++ b/tests/Unit/Jobs/SyncStoreCustomersFromStripeJobBatchableTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\SyncStoreCustomersFromStripeJob;
+use App\Models\Store;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Container\Container;
+use Illuminate\Support\Collection;
+
+it('uses the Batchable trait so it can be dispatched inside Bus batches', function (): void {
+    expect(class_uses_recursive(SyncStoreCustomersFromStripeJob::class))
+        ->toContain(Batchable::class);
+});
+
+it('does not throw when composed into a pending bus batch', function (): void {
+    expect(fn (): PendingBatch => new PendingBatch(
+        new Container,
+        Collection::wrap([
+            new SyncStoreCustomersFromStripeJob(Mockery::mock(Store::class)),
+        ]),
+    ))->not->toThrow(RuntimeException::class);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks https://github.com/janiator/filament-pos-stripe/issues/135 (**Nightwatch issue id:** `nw-ref-7`, NW #7).

## Cause

`SyncEverythingFromStripeJob` and `SyncStoreEverythingFromStripeJob` enqueue `SyncStoreCustomersFromStripeJob` through `Bus::batch()`. Laravel’s `Illuminate\Bus\PendingBatch` rejects any queued job that does not use `Illuminate\Bus\Batchable`, throwing `RuntimeException: Attempted to batch job [...], but it does not use the Batchable trait.` That matches the Nightwatch exception.

## Fix

Confirm `SyncStoreCustomersFromStripeJob` keeps `Batchable` (required for those coordinators). Add a short class docblock explaining why the trait must stay, so it is not removed accidentally during refactors.

## How to verify

```bash
./vendor/bin/pest tests/Unit/Jobs/SyncStoreCustomersFromStripeJobBatchableTest.php --compact
```

The tests assert the trait is present and that constructing a `PendingBatch` with this job does not throw (same validation `Bus::batch()` performs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3314fe7-54ff-4048-8a8b-6d8b083b1f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3314fe7-54ff-4048-8a8b-6d8b083b1f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

