### PR TITLE
Fix Nightwatch nw-ref-6: parse product declaration_date before format()

### DIFF
--- a/app/Http/Controllers/Api/ProductDeclarationController.php
+++ b/app/Http/Controllers/Api/ProductDeclarationController.php
@@ -14,8 +14,8 @@ class ProductDeclarationController extends BaseApiController
     public function show(Request $request): JsonResponse
     {
         $store = $this->getTenantStore($request);
-        
-        if (!$store) {
+
+        if (! $store) {
             return response()->json(['message' => 'Store not found'], 404);
         }
 
@@ -23,7 +23,7 @@ class ProductDeclarationController extends BaseApiController
 
         $declaration = ProductDeclaration::getActiveForStore($store->id);
 
-        if (!$declaration) {
+        if (! $declaration) {
             return response()->json(['message' => 'No active product declaration found'], 404);
         }
 
@@ -34,7 +34,7 @@ class ProductDeclarationController extends BaseApiController
                 'vendor_name' => $declaration->vendor_name,
                 'version' => $declaration->version,
                 'version_identification' => $declaration->version_identification,
-                'declaration_date' => $declaration->declaration_date?->format('Y-m-d'),
+                'declaration_date' => $declaration->resolvedDeclarationDate()?->format('Y-m-d'),
                 'content' => $declaration->content,
                 'created_at' => $this->formatDateTimeOslo($declaration->created_at),
                 'updated_at' => $this->formatDateTimeOslo($declaration->updated_at),
@@ -48,8 +48,8 @@ class ProductDeclarationController extends BaseApiController
     public function display(Request $request)
     {
         $store = $this->getTenantStore($request);
-        
-        if (!$store) {
+
+        if (! $store) {
             abort(404, 'Store not found');
         }
 
@@ -57,13 +57,13 @@ class ProductDeclarationController extends BaseApiController
 
         $declaration = ProductDeclaration::getActiveForStore($store->id);
 
-        if (!$declaration) {
+        if (! $declaration) {
             abort(404, 'No active product declaration found');
         }
 
         // Convert markdown to HTML
         $content = $declaration->content;
-        
+
         // Use a simple markdown parser (you might want to use a proper library like Parsedown)
         // For now, we'll use basic markdown conversion
         $htmlContent = $this->markdownToHtml($content);
@@ -82,60 +82,61 @@ class ProductDeclarationController extends BaseApiController
     {
         // Basic markdown conversion
         $html = $markdown;
-        
+
         // Headers
         $html = preg_replace('/^### (.*)$/m', '<h3>$1</h3>', $html);
         $html = preg_replace('/^## (.*)$/m', '<h2>$1</h2>', $html);
         $html = preg_replace('/^# (.*)$/m', '<h1>$1</h1>', $html);
-        
+
         // Bold
         $html = preg_replace('/\*\*(.*?)\*\*/', '<strong>$1</strong>', $html);
-        
+
         // Italic
         $html = preg_replace('/\*(.*?)\*/', '<em>$1</em>', $html);
-        
+
         // Lists
         $html = preg_replace('/^\- (.*)$/m', '<li>$1</li>', $html);
         $html = preg_replace('/^(\d+)\. (.*)$/m', '<li>$2</li>', $html);
-        
+
         // Wrap consecutive list items in ul/ol
         $html = preg_replace('/(<li>.*<\/li>\n?)+/m', '<ul>$0</ul>', $html);
-        
+
         // Paragraphs (lines that aren't headers or list items)
         $lines = explode("\n", $html);
         $result = [];
         $inList = false;
-        
+
         foreach ($lines as $line) {
             $trimmed = trim($line);
             if (empty($trimmed)) {
                 $result[] = '';
+
                 continue;
             }
-            
+
             if (strpos($trimmed, '<h') === 0 || strpos($trimmed, '<ul') === 0 || strpos($trimmed, '</ul') === 0) {
                 $result[] = $line;
             } elseif (strpos($trimmed, '<li') === 0) {
                 $result[] = $line;
             } else {
-                $result[] = '<p>' . $trimmed . '</p>';
+                $result[] = '<p>'.$trimmed.'</p>';
             }
         }
-        
+
         $html = implode("\n", $result);
-        
+
         // Code blocks
         $html = preg_replace('/```(\w+)?\n(.*?)```/s', '<pre><code>$2</code></pre>', $html);
-        
+
         // Inline code
         $html = preg_replace('/`(.*?)`/', '<code>$1</code>', $html);
-        
+
         // Links
         $html = preg_replace('/\[([^\]]+)\]\(([^\)]+)\)/', '<a href="$2">$1</a>', $html);
-        
+
         // Horizontal rules
         $html = preg_replace('/^---$/m', '<hr>', $html);
-        
+
         return $html;
     }
 }

--- a/app/Models/ProductDeclaration.php
+++ b/app/Models/ProductDeclaration.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 class ProductDeclaration extends Model
 {
@@ -32,6 +34,26 @@ class ProductDeclaration extends Model
     public function store(): BelongsTo
     {
         return $this->belongsTo(Store::class);
+    }
+
+    /**
+     * Resolve declaration_date for display/API formatting (Carbon instance or date string).
+     */
+    public function resolvedDeclarationDate(): ?CarbonInterface
+    {
+        $attributes = $this->getAttributes();
+
+        if (array_key_exists('declaration_date', $attributes)) {
+            $value = $attributes['declaration_date'];
+        } else {
+            $value = $this->getAttribute('declaration_date');
+        }
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return Carbon::parse($value);
     }
 
     /**

--- a/resources/views/product-declaration.blade.php
+++ b/resources/views/product-declaration.blade.php
@@ -182,8 +182,9 @@
                 @endif
                 <span><strong>Versjon:</strong> {{ $declaration->version }}</span>
                 <span><strong>Versjonsidentifikasjon:</strong> {{ $declaration->version_identification }}</span>
-                @if($declaration->declaration_date)
-                    <span><strong>Dato:</strong> {{ $declaration->declaration_date->format('d.m.Y') }}</span>
+                @php($resolvedDeclarationDate = $declaration->resolvedDeclarationDate())
+                @if($resolvedDeclarationDate)
+                    <span><strong>Dato:</strong> {{ $resolvedDeclarationDate->format('d.m.Y') }}</span>
                 @endif
             </div>
         </div>

--- a/tests/Feature/ProductDeclarationApiTest.php
+++ b/tests/Feature/ProductDeclarationApiTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\ProductDeclaration;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+test('product declaration show json formats declaration_date', function () {
+    $user = User::factory()->create();
+    $store = Store::factory()->create();
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    ProductDeclaration::query()->create([
+        'store_id' => $store->id,
+        'product_name' => 'Test Product',
+        'vendor_name' => 'Vendor',
+        'version' => '1.0.0',
+        'version_identification' => 'TEST-1',
+        'declaration_date' => '2026-05-16',
+        'content' => 'Body',
+        'is_active' => true,
+    ]);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->getJson('/api/product-declaration');
+
+    $response->assertOk();
+    $response->assertJsonPath('data.declaration_date', '2026-05-16');
+});
+
+test('resolvedDeclarationDate parses string when attribute is stored without casting', function () {
+    $declaration = new ProductDeclaration;
+
+    ProductDeclaration::withoutCasting(function () use ($declaration): void {
+        $declaration->forceFill([
+            'store_id' => 1,
+            'product_name' => 'Test Product',
+            'vendor_name' => 'Vendor',
+            'version' => '1.0.0',
+            'version_identification' => 'TEST-1',
+            'declaration_date' => '2026-05-16',
+            'content' => 'Body',
+            'is_active' => true,
+        ]);
+    });
+
+    expect($declaration->resolvedDeclarationDate())->not->toBeNull();
+    expect($declaration->resolvedDeclarationDate()?->format('Y-m-d'))->toBe('2026-05-16');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes https://github.com/janiator/filament-pos-stripe/issues/137 (**Nightwatch `nw-ref-6`**, [NW #6](https://github.com/janiator/filament-pos-stripe/issues/137)).

## Cause

`declaration_date` could be present as a **plain string** (raw attribute / missing cast path) while the API and the product declaration HTML view called `->format()` as if the value were always a `Carbon` instance. The nullsafe chain `?->format()` does **not** help: a non-null string still invokes `format()` on a string and triggers **Call to a member function format() on string**.

## Fix

- Added `ProductDeclaration::resolvedDeclarationDate()` to normalize the value with `Carbon::parse()`, preferring the raw attribute value from `getAttributes()` when the key exists (so we do not assume it was cast to `Carbon`).
- `ProductDeclarationController@show` and `resources/views/product-declaration.blade.php` now use this resolver before formatting.

## How to verify

```bash
php artisan test --compact tests/Feature/ProductDeclarationApiTest.php
```

The second test reproduces an uncast string on the model via `Model::withoutCasting` + `forceFill` and asserts `resolvedDeclarationDate()` formats without error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c78458ea-8241-44ce-9f49-1ba69723bc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c78458ea-8241-44ce-9f49-1ba69723bc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

