### PR TITLE
Stripe: sync Connect product default_price before archiving old price (#139 / nw-ref-1)

### DIFF
--- a/app/Actions/ConnectedPrices/SyncProductPrice.php
+++ b/app/Actions/ConnectedPrices/SyncProductPrice.php
@@ -88,8 +88,7 @@ class SyncProductPrice
         }
 
         // Create new price
-        $createPriceAction = new CreateConnectedPriceInStripe;
-        $newPriceId = $createPriceAction(
+        $newPriceId = app(CreateConnectedPriceInStripe::class)(
             $product->stripe_product_id,
             $product->stripe_account_id,
             $newPriceAmount,
@@ -114,6 +113,18 @@ class SyncProductPrice
         // Set as default price
         $product->default_price = $newPriceId;
         $product->saveQuietly();
+
+        // Stripe rejects archiving/deactivating a Price that still is the Product's default_price on
+        // the connected account. Push the new default_price to Stripe before touching old Prices.
+        if (! $this->syncStripeProductDefaultPrice($product, $newPriceId)) {
+            Log::error('Aborted archiving old prices: failed to update Stripe product default_price', [
+                'product_id' => $product->id,
+                'stripe_product_id' => $product->stripe_product_id,
+                'new_default_price_id' => $newPriceId,
+            ]);
+
+            return;
+        }
 
         // Handle old prices - archive if used, delete if not
         foreach ($existingPrices as $oldPrice) {
@@ -173,7 +184,7 @@ class SyncProductPrice
                 return false;
             }
 
-            $stripe = new StripeClient($secret);
+            $stripe = $this->makeStripeClient($secret);
 
             // Check payment intents - search for this price ID
             // Note: Payment intents don't directly store price_id, but we can check metadata
@@ -215,6 +226,48 @@ class SyncProductPrice
         return false;
     }
 
+    protected function makeStripeClient(string $secret): StripeClient
+    {
+        return new StripeClient($secret);
+    }
+
+    /**
+     * Update the Stripe Product's default_price (Connect) before deactivating the previous price.
+     */
+    protected function syncStripeProductDefaultPrice(ConnectedProduct $product, string $defaultPriceId): bool
+    {
+        try {
+            $secret = config('cashier.secret') ?? config('services.stripe.secret');
+            if (! $secret) {
+                Log::warning('Cannot sync Stripe product default price: Stripe secret not configured', [
+                    'product_id' => $product->id,
+                ]);
+
+                return false;
+            }
+
+            $stripe = $this->makeStripeClient($secret);
+
+            $stripe->products->update(
+                $product->stripe_product_id,
+                ['default_price' => $defaultPriceId],
+                ['stripe_account' => $product->stripe_account_id]
+            );
+
+            return true;
+        } catch (Throwable $e) {
+            Log::error('Failed to sync Stripe product default price', [
+                'product_id' => $product->id,
+                'stripe_product_id' => $product->stripe_product_id,
+                'default_price_id' => $defaultPriceId,
+                'error' => $e->getMessage(),
+            ]);
+            report($e);
+
+            return false;
+        }
+    }
+
     /**
      * Archive a price in Stripe (set active=false)
      */
@@ -226,7 +279,7 @@ class SyncProductPrice
                 return;
             }
 
-            $stripe = new StripeClient($secret);
+            $stripe = $this->makeStripeClient($secret);
 
             $stripe->prices->update(
                 $price->stripe_price_id,
@@ -257,7 +310,7 @@ class SyncProductPrice
                 return;
             }
 
-            $stripe = new StripeClient($secret);
+            $stripe = $this->makeStripeClient($secret);
 
             // Try to delete, but Stripe may not allow deletion if price has been used
             // In that case, we'll archive it instead

--- a/tests/Feature/SyncProductPriceTest.php
+++ b/tests/Feature/SyncProductPriceTest.php
@@ -1,16 +1,130 @@
 <?php
 
+use App\Actions\ConnectedPrices\CreateConnectedPriceInStripe;
 use App\Actions\ConnectedPrices\SyncProductPrice;
 use App\Models\ConnectedPrice;
 use App\Models\ConnectedProduct;
 use App\Models\Store;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Lanos\CashierConnect\Models\ConnectMapping;
+use Stripe\StripeClient;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Log::spy();
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('calls Stripe products.update to set default before prices.delete when creating a replacement price', function () {
+    config(['cashier.secret' => 'sk_test_fixture']);
+
+    $this->mock(CreateConnectedPriceInStripe::class)
+        ->shouldReceive('__invoke')
+        ->once()
+        ->andReturn('price_new_fixture');
+
+    $store = Store::factory()->create();
+    ConnectMapping::query()->create([
+        'model' => Store::class,
+        'model_id' => $store->id,
+        'stripe_account_id' => $store->stripe_account_id,
+        'type' => 'standard',
+    ]);
+    $accountId = $store->stripe_account_id;
+
+    $product = ConnectedProduct::withoutEvents(fn (): ConnectedProduct => ConnectedProduct::factory()->create([
+        'stripe_account_id' => $accountId,
+        'stripe_product_id' => 'prod_sync_api_order_test',
+        'price' => '75.00',
+        'currency' => 'nok',
+    ]));
+
+    $previousDefaultPriceId = 'price_previous_default_test';
+
+    ConnectedPrice::create([
+        'stripe_price_id' => $previousDefaultPriceId,
+        'stripe_account_id' => $accountId,
+        'stripe_product_id' => $product->stripe_product_id,
+        'unit_amount' => 5000,
+        'currency' => 'nok',
+        'type' => 'one_time',
+        'active' => true,
+        'billing_scheme' => 'per_unit',
+        'metadata' => [],
+        'nickname' => null,
+        'recurring_interval' => null,
+        'recurring_interval_count' => null,
+        'recurring_usage_type' => null,
+        'recurring_aggregate_usage' => null,
+        'tiers_mode' => null,
+    ]);
+
+    $product->default_price = $previousDefaultPriceId;
+    $product->saveQuietly();
+
+    $stripeCallOrder = [];
+    $newPriceId = 'price_new_fixture';
+
+    $mockPrices = Mockery::mock();
+    $mockPrices->shouldReceive('delete')->once()->andReturnUsing(function (
+        string $priceId,
+        array $_params,
+        array $opts,
+    ) use (&$stripeCallOrder, $previousDefaultPriceId, $accountId): object {
+        $stripeCallOrder[] = 'prices.delete';
+        expect($priceId)->toBe($previousDefaultPriceId)
+            ->and($opts['stripe_account'] ?? null)->toBe($accountId);
+
+        return (object) ['id' => $priceId, 'deleted' => true];
+    });
+
+    $mockProducts = Mockery::mock();
+    $mockProducts->shouldReceive('update')->once()->andReturnUsing(function (
+        string $stripeProductId,
+        array $payload,
+        array $opts,
+    ) use (&$stripeCallOrder, $product, $newPriceId, $accountId): object {
+        $stripeCallOrder[] = 'products.update';
+
+        expect($stripeProductId)->toBe($product->stripe_product_id)
+            ->and($payload['default_price'] ?? null)->toBe($newPriceId)
+            ->and($opts['stripe_account'] ?? null)->toBe($accountId);
+
+        return (object) ['id' => $stripeProductId];
+    });
+
+    $stripeClient = Mockery::mock(StripeClient::class);
+    $stripeClient->prices = $mockPrices;
+    $stripeClient->products = $mockProducts;
+
+    $sync = new class($stripeClient) extends SyncProductPrice
+    {
+        public function __construct(private readonly StripeClient $stripeClientInstance) {}
+
+        protected function makeStripeClient(string $secret): StripeClient
+        {
+            return $this->stripeClientInstance;
+        }
+
+        protected function priceHasBeenUsed(ConnectedPrice $price): bool
+        {
+            return false;
+        }
+    };
+
+    $sync->__invoke($product);
+
+    expect($stripeCallOrder)->toBe([
+        'products.update',
+        'prices.delete',
+    ]);
+    expect($product->fresh()->default_price)->toBe($newPriceId)
+        ->and(ConnectedPrice::query()->where('stripe_price_id', $previousDefaultPriceId)->exists())->toBeFalse();
 });
 
 it('reads the current attribute value, not getRawOriginal, for price resolution', function () {
@@ -97,4 +211,3 @@ it('skips sync for products without stripe_product_id', function () {
 
     expect(ConnectedPrice::where('stripe_product_id', null)->count())->toBe(0);
 });
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to GitHub [#139](https://github.com/janiator/filament-pos-stripe/issues/139) (Stripe: cannot archive default price — legacy/Nightwatch ref).

**Nightwatch**: issue id `nw-ref-1`; Nightwatch ref `#1`.

## Cause

`SyncProductPrice` persisted the new price id locally (`default_price` + `saveQuietly()`), then called Stripe to archive/delete **other** prices. On Stripe Connect, while the Stripe **Product** still pointed at the old price as **`default_price`**, Stripe rejects deactivating that price (`cannot archive default price of product`). The queued/listener Stripe product sync is not guaranteed to run before price cleanup inside this action; `saveQuietly()` also skips model events.

## Fix

Before iterating old prices:

1. Call `products.update` on the Connect account with `{ default_price: <new_price_id> }`.
2. If that update fails (missing secret/API error), log, report, **return** — do **not** attempt to archive/delete the previous default until Stripe’s product pointer is successfully moved.

Supporting changes for regression coverage:

- `CreateConnectedPriceInStripe` is resolved via `app()` so tests can substitute a mock safely.
- `makeStripeClient()` centralizes Stripe client construction so tests can inject a mocked `StripeClient`.

## How to verify

Against a Postgres test database (matching `phpunit.xml`, e.g. `pos_stripe_test`) with credentials in the environment:

`php artisan test --compact tests/Feature/SyncProductPriceTest.php`

The new regression test asserts Stripe API ordering: **`products.update` sets `default_price` before `prices.delete`** runs on the superseded unused price path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-943ec3c5-4b3d-4f9d-8abd-cb76703ead1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-943ec3c5-4b3d-4f9d-8abd-cb76703ead1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

