### PR TITLE
fix(pos): correct per-item VAT on checkout and purchase display

### DIFF
--- a/app/Filament/Resources/PosPurchases/Schemas/PosPurchaseInfolist.php
+++ b/app/Filament/Resources/PosPurchases/Schemas/PosPurchaseInfolist.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\PosPurchases\Schemas;
 
+use App\Support\VatRateNormalizer;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\RepeatableEntry\TableColumn;
@@ -11,7 +12,6 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\IconSize;
 use Filament\Support\Enums\TextSize;
-use Filament\Support\Icons\Heroicon;
 
 class PosPurchaseInfolist
 {
@@ -116,7 +116,7 @@ class PosPurchaseInfolist
         }
         $agc = \App\Models\ArticleGroupCode::where('code', $code)->where('active', true)->first();
         if ($agc && $agc->default_vat_percent !== null) {
-            return (float) $agc->default_vat_percent;
+            return VatRateNormalizer::toDecimal((float) $agc->default_vat_percent);
         }
 
         return 0.25;
@@ -145,13 +145,13 @@ class PosPurchaseInfolist
             }
             $rate = null;
             if (isset($item['tax_rate']) && $item['tax_rate'] !== null && $item['tax_rate'] !== '') {
-                $rate = (float) $item['tax_rate'];
+                $rate = VatRateNormalizer::toDecimal((float) $item['tax_rate']);
             }
             if ($rate === null) {
                 $code = $item['article_group_code'] ?? null;
                 $rate = self::getTaxRateForArticleGroupCode($code);
             }
-            $ratePercent = (int) round($rate * 100);
+            $ratePercent = VatRateNormalizer::toDisplayPercent($rate);
             $lineTaxOre = $rate > 0 ? (int) round($lineSubtotalOre * ($rate / (1 + $rate))) : 0;
             if (! isset($byRate[$ratePercent])) {
                 $byRate[$ratePercent] = 0;

--- a/app/Http/Controllers/Api/PurchasesController.php
+++ b/app/Http/Controllers/Api/PurchasesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\ConnectedProducts\ResolveProductVatRate;
 use App\Exceptions\CashDrawerDisabledException;
 use App\Exceptions\InsufficientStockException;
 use App\Http\Requests\Api\CompletePurchasePaymentRequest;
@@ -12,6 +13,7 @@ use App\Models\PaymentMethod;
 use App\Models\PosSession;
 use App\Models\ProductVariant;
 use App\Services\PurchaseService;
+use App\Support\VatRateNormalizer;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -1127,6 +1129,13 @@ class PurchasesController extends BaseApiController
             $isFullyRefunded = $quantityRefunded >= $quantity;
             $isPartiallyRefunded = $quantityRefunded > 0 && $quantityRefunded < $quantity;
 
+            $itemTaxRate = null;
+            if (isset($item['tax_rate']) && $item['tax_rate'] !== null && $item['tax_rate'] !== '') {
+                $itemTaxRate = VatRateNormalizer::toDecimal((float) $item['tax_rate']);
+            } elseif ($product !== null) {
+                $itemTaxRate = app(ResolveProductVatRate::class)($product);
+            }
+
             $out[] = [
                 'purchase_item_id' => $itemId,
                 'purchase_item_product_id' => $productId ? (string) $productId : null,
@@ -1144,6 +1153,7 @@ class PurchasesController extends BaseApiController
                 'purchase_item_discount_amount' => $discountAmount > 0 ? $discountAmount : null,
                 'purchase_item_discount_reason' => $item['discount_reason'] ?? null,
                 'purchase_item_article_group_code' => $articleGroupCode,
+                'purchase_item_tax_rate' => $itemTaxRate,
                 'purchase_item_product_code' => $productCode,
                 'purchase_item_metadata' => isset($item['metadata']) && is_array($item['metadata'])
                     ? $item['metadata']

--- a/app/Services/PurchaseService.php
+++ b/app/Services/PurchaseService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Actions\ConnectedProducts\ResolveProductVatRate;
 use App\Models\ConnectedCharge;
 use App\Models\ConnectedProduct;
 use App\Models\PaymentMethod;
@@ -1249,6 +1250,14 @@ class PurchaseService
                 'article_group_code' => $articleGroupCode,
                 'product_code' => $productCode,
             ]);
+
+            if ($product !== null) {
+                $enrichedItem['tax_rate'] = app(ResolveProductVatRate::class)($product);
+            } elseif (! isset($enrichedItem['tax_rate']) || $enrichedItem['tax_rate'] === null || $enrichedItem['tax_rate'] === '') {
+                $enrichedItem['tax_rate'] = 0.25;
+            } else {
+                $enrichedItem['tax_rate'] = \App\Support\VatRateNormalizer::toDecimal((float) $enrichedItem['tax_rate']);
+            }
 
             return $enrichedItem;
         }, $items);

--- a/app/Services/ReceiptTemplateService.php
+++ b/app/Services/ReceiptTemplateService.php
@@ -2,10 +2,10 @@
 
 namespace App\Services;
 
-use App\Models\PaymentMethod;
 use App\Models\Receipt;
 use App\Models\ReceiptTemplate;
 use App\Models\Store;
+use App\Support\VatRateNormalizer;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
@@ -471,18 +471,18 @@ class ReceiptTemplateService
 
             $rate = null;
             if (isset($raw['tax_rate']) && is_numeric($raw['tax_rate'])) {
-                $rate = (float) $raw['tax_rate'];
+                $rate = VatRateNormalizer::toDecimal((float) $raw['tax_rate']);
             }
             if ($rate === null && ! empty($raw['article_group_code'])) {
                 $agc = \App\Models\ArticleGroupCode::where('code', $raw['article_group_code'])->first();
                 if ($agc !== null && $agc->default_vat_percent !== null) {
-                    $rate = (float) $agc->default_vat_percent;
+                    $rate = VatRateNormalizer::toDecimal((float) $agc->default_vat_percent);
                 }
             }
             if ($rate === null) {
                 $rate = 25.0;
             }
-            // Normalize: DB may store 0.15 / 0.25 (decimal); we use percentage (15, 25) everywhere
+            // Use percentage (15, 25) in breakdown output
             if ($rate > 0 && $rate <= 1) {
                 $rate = $rate * 100;
             }

--- a/app/Support/VatRateNormalizer.php
+++ b/app/Support/VatRateNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Support;
+
+final class VatRateNormalizer
+{
+    /**
+     * Normalize a VAT rate to decimal form (0–1), e.g. 15 → 0.15, 0.15 → 0.15.
+     */
+    public static function toDecimal(?float $rate, float $default = 0.25): float
+    {
+        if ($rate === null) {
+            return $default;
+        }
+
+        if ($rate <= 0) {
+            return 0.0;
+        }
+
+        if ($rate > 1) {
+            return $rate / 100;
+        }
+
+        return $rate;
+    }
+
+    /**
+     * Display percent (0–100) from decimal rate.
+     */
+    public static function toDisplayPercent(float $decimalRate): int
+    {
+        return (int) round(self::toDecimal($decimalRate) * 100);
+    }
+
+    /**
+     * Extract tax (øre) from a tax-inclusive amount.
+     */
+    public static function extractTaxOreFromInclusiveAmount(int $amountOre, float $decimalRate): int
+    {
+        $rate = self::toDecimal($decimalRate);
+
+        if ($rate <= 0 || $amountOre <= 0) {
+            return 0;
+        }
+
+        return (int) round($amountOre * ($rate / (1 + $rate)));
+    }
+}

--- a/docs/flutterflow/custom-actions/cart_tax_rate_helpers.dart
+++ b/docs/flutterflow/custom-actions/cart_tax_rate_helpers.dart
@@ -1,0 +1,62 @@
+/// Shared VAT helpers for cart/checkout custom actions (body-only snippets).
+/// Copy these functions into each action that builds API cart payloads or calculates tax.
+/// Do not push this file as a standalone FlutterFlow action.
+
+/// Maps tax codes / article group hints to decimal VAT rate (0–1).
+double getTaxPercentageFromCode(String? taxCode) {
+  if (taxCode == null || taxCode.isEmpty) {
+    return 0.25;
+  }
+
+  switch (taxCode.toLowerCase()) {
+    case 'txcd_99999999':
+    case 'standard':
+    case '1':
+      return 0.25;
+    case 'txcd_99999998':
+    case 'reduced':
+    case 'food':
+      return 0.15;
+    case 'txcd_99999997':
+    case 'lower':
+    case 'service':
+      return 0.10;
+    case 'txcd_99999996':
+    case 'zero':
+    case 'exempt':
+    case '0':
+      return 0.0;
+    default:
+      return 0.25;
+  }
+}
+
+/// Normalize API/product tax percent to decimal rate 0–1.
+double normalizeTaxRateDecimal(double? rate, {double defaultRate = 0.25}) {
+  if (rate == null) {
+    return defaultRate;
+  }
+  if (rate == 0) {
+    return 0.0;
+  }
+  if (rate > 1) {
+    return rate / 100.0;
+  }
+
+  return rate;
+}
+
+/// Resolve effective VAT decimal rate for a cart line (0–1) for API `tax_rate`.
+double resolveCartItemTaxRate(CartItemsStruct item) {
+  final stored = item.cartItemTaxPercent;
+  if (stored != null) {
+    return normalizeTaxRateDecimal(stored);
+  }
+
+  final code = item.cartItemArticleGroupCode.trim();
+  if (code.isNotEmpty) {
+    return getTaxPercentageFromCode(code);
+  }
+
+  return 0.25;
+}

--- a/docs/flutterflow/custom-actions/complete_pos_purchase.dart
+++ b/docs/flutterflow/custom-actions/complete_pos_purchase.dart
@@ -30,6 +30,62 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+double getTaxPercentageFromCode(String? taxCode) {
+  if (taxCode == null || taxCode.isEmpty) {
+    return 0.25;
+  }
+
+  switch (taxCode.toLowerCase()) {
+    case 'txcd_99999999':
+    case 'standard':
+    case '1':
+      return 0.25;
+    case 'txcd_99999998':
+    case 'reduced':
+    case 'food':
+      return 0.15;
+    case 'txcd_99999997':
+    case 'lower':
+    case 'service':
+      return 0.10;
+    case 'txcd_99999996':
+    case 'zero':
+    case 'exempt':
+    case '0':
+      return 0.0;
+    default:
+      return 0.25;
+  }
+}
+
+double normalizeTaxRateDecimal(double? rate, {double defaultRate = 0.25}) {
+  if (rate == null) {
+    return defaultRate;
+  }
+  if (rate == 0) {
+    return 0.0;
+  }
+  if (rate > 1) {
+    return rate / 100.0;
+  }
+
+  return rate;
+}
+
+double resolveCartItemTaxRate(CartItemsStruct item) {
+  final stored = item.cartItemTaxPercent;
+  if (stored != null) {
+    return normalizeTaxRateDecimal(stored);
+  }
+
+  final code = item.cartItemArticleGroupCode.trim();
+  if (code.isNotEmpty) {
+    return getTaxPercentageFromCode(code);
+  }
+
+  return 0.25;
+}
+
 const String kPositivDeferredResumeChargeIdKey =
     'positiv_deferred_resume_charge_id';
 const String kPositivDeferredResumeOrderLabelKey =
@@ -485,9 +541,12 @@ Future<dynamic> completePosPurchase(
       };
     }
 
+    await updateCartTotals();
+    final cartWithTotals = FFAppState().cart;
+
     // Build cart items array from cartItems
     final List<Map<String, dynamic>> cartItems = [];
-    for (var cartItem in cart.cartItems) {
+    for (var cartItem in cartWithTotals.cartItems) {
       // Get product ID (assuming it's stored as string, convert to int)
       final productId = int.tryParse(cartItem.cartItemProductId) ?? 0;
 
@@ -510,14 +569,14 @@ Future<dynamic> completePosPurchase(
         'quantity': cartItem.cartItemQuantity,
         'unit_price': unitPrice,
         'discount_amount': discountAmount,
-        'tax_rate': 0.25, // Norwegian VAT rate
+        'tax_rate': resolveCartItemTaxRate(cartItem),
         'tax_inclusive': true,
       });
     }
 
     // Build discounts array from cartDiscounts
     final List<Map<String, dynamic>> cartDiscounts = [];
-    for (var discount in cart.cartDiscounts) {
+    for (var discount in cartWithTotals.cartDiscounts) {
       final discountType = discount.cartDiscountType.isNotEmpty
           ? discount.cartDiscountType
           : 'fixed'; // Default to 'fixed' if empty
@@ -551,20 +610,19 @@ Future<dynamic> completePosPurchase(
     }
 
     // Get totals from cart (already calculated)
-    final subtotal = cart.cartSubtotalExcludingTax; // in øre
-    final totalDiscounts = cart
-        .cartTotalDiscount; // in øre (includes both item and cart discounts)
-    final totalTax = cart.cartTotalTax; // in øre
-    final total = cart.cartTotalCartPrice; // in øre
-    final tipAmount = cart.cartTipAmount; // in øre
+    final subtotal = cartWithTotals.cartSubtotalExcludingTax;
+    final totalDiscounts = cartWithTotals.cartTotalDiscount;
+    final totalTax = cartWithTotals.cartTotalTax;
+    final total = cartWithTotals.cartTotalCartPrice;
+    final tipAmount = cartWithTotals.cartTipAmount;
 
     // Get customer ID from cart
     // Note: customer_id should be the local database ID (integer), not the Stripe customer ID
     // The backend will resolve the local ID to the Stripe customer ID automatically
     // cartCustomerId is already an integer (local database ID)
     final dynamic customerIdForApi =
-        cart.cartCustomerId != null && cart.cartCustomerId! > 0
-        ? cart.cartCustomerId
+        cartWithTotals.cartCustomerId != null && cartWithTotals.cartCustomerId! > 0
+        ? cartWithTotals.cartCustomerId
         : null;
 
     // Build cart object
@@ -574,10 +632,10 @@ Future<dynamic> completePosPurchase(
       'tip_amount': tipAmount,
       'customer_id':
           customerIdForApi, // Local customer ID (integer) - backend will resolve to Stripe ID
-      'customer_name': cart.cartCustomerName.isNotEmpty
-          ? cart.cartCustomerName
+      'customer_name': cartWithTotals.cartCustomerName.isNotEmpty
+          ? cartWithTotals.cartCustomerName
           : null,
-      'note': cart.cartNote.isNotEmpty ? cart.cartNote : null,
+      'note': cartWithTotals.cartNote.isNotEmpty ? cartWithTotals.cartNote : null,
       'subtotal': subtotal,
       'total_discounts': totalDiscounts,
       'total_tax': totalTax,

--- a/docs/flutterflow/custom-actions/prepare_parked_deferred_purchase.dart
+++ b/docs/flutterflow/custom-actions/prepare_parked_deferred_purchase.dart
@@ -16,6 +16,62 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+double getTaxPercentageFromCode(String? taxCode) {
+  if (taxCode == null || taxCode.isEmpty) {
+    return 0.25;
+  }
+
+  switch (taxCode.toLowerCase()) {
+    case 'txcd_99999999':
+    case 'standard':
+    case '1':
+      return 0.25;
+    case 'txcd_99999998':
+    case 'reduced':
+    case 'food':
+      return 0.15;
+    case 'txcd_99999997':
+    case 'lower':
+    case 'service':
+      return 0.10;
+    case 'txcd_99999996':
+    case 'zero':
+    case 'exempt':
+    case '0':
+      return 0.0;
+    default:
+      return 0.25;
+  }
+}
+
+double normalizeTaxRateDecimal(double? rate, {double defaultRate = 0.25}) {
+  if (rate == null) {
+    return defaultRate;
+  }
+  if (rate == 0) {
+    return 0.0;
+  }
+  if (rate > 1) {
+    return rate / 100.0;
+  }
+
+  return rate;
+}
+
+double resolveCartItemTaxRate(CartItemsStruct item) {
+  final stored = item.cartItemTaxPercent;
+  if (stored != null) {
+    return normalizeTaxRateDecimal(stored);
+  }
+
+  final code = item.cartItemArticleGroupCode.trim();
+  if (code.isNotEmpty) {
+    return getTaxPercentageFromCode(code);
+  }
+
+  return 0.25;
+}
+
 const String kPositivDeferredResumeChargeIdKey =
     'positiv_deferred_resume_charge_id';
 const String kPositivDeferredResumeOrderLabelKey =
@@ -133,6 +189,9 @@ Future<dynamic> prepareParkedDeferredPurchase(
       final lineId = m['purchase_item_id']?.toString() ??
           DateTime.now().microsecondsSinceEpoch.toString();
 
+      final taxRateRaw = m['purchase_item_tax_rate'] as num?;
+      final taxPct = taxRateRaw != null ? taxRateRaw.toDouble() : null;
+
       cartItems.add(
         CartItemsStruct(
           cartItemId: lineId,
@@ -146,6 +205,7 @@ Future<dynamic> prepareParkedDeferredPurchase(
           cartItemDiscountAmount: disc,
           cartItemDiscountReason: discReason,
           cartItemArticleGroupCode: article,
+          cartItemTaxPercent: taxPct,
           cartItemProductCode: productCode,
           cartItemMetadata: null,
         ),
@@ -436,7 +496,7 @@ Map<String, dynamic> _buildCartPayloadFromShoppingCart(ShoppingCartStruct cart) 
       'quantity': cartItem.cartItemQuantity,
       'unit_price': unitPrice,
       'discount_amount': discountAmount,
-      'tax_rate': 0.25,
+      'tax_rate': resolveCartItemTaxRate(cartItem),
       'tax_inclusive': true,
     });
   }

--- a/docs/flutterflow/custom-actions/serialize_cart_for_complete_deferred.dart
+++ b/docs/flutterflow/custom-actions/serialize_cart_for_complete_deferred.dart
@@ -8,6 +8,62 @@
 
 import 'dart:convert';
 
+double getTaxPercentageFromCode(String? taxCode) {
+  if (taxCode == null || taxCode.isEmpty) {
+    return 0.25;
+  }
+
+  switch (taxCode.toLowerCase()) {
+    case 'txcd_99999999':
+    case 'standard':
+    case '1':
+      return 0.25;
+    case 'txcd_99999998':
+    case 'reduced':
+    case 'food':
+      return 0.15;
+    case 'txcd_99999997':
+    case 'lower':
+    case 'service':
+      return 0.10;
+    case 'txcd_99999996':
+    case 'zero':
+    case 'exempt':
+    case '0':
+      return 0.0;
+    default:
+      return 0.25;
+  }
+}
+
+double normalizeTaxRateDecimal(double? rate, {double defaultRate = 0.25}) {
+  if (rate == null) {
+    return defaultRate;
+  }
+  if (rate == 0) {
+    return 0.0;
+  }
+  if (rate > 1) {
+    return rate / 100.0;
+  }
+
+  return rate;
+}
+
+double resolveCartItemTaxRate(CartItemsStruct item) {
+  final stored = item.cartItemTaxPercent;
+  if (stored != null) {
+    return normalizeTaxRateDecimal(stored);
+  }
+
+  final code = item.cartItemArticleGroupCode.trim();
+  if (code.isNotEmpty) {
+    return getTaxPercentageFromCode(code);
+  }
+
+  return 0.25;
+}
+
 Future<dynamic> serializeCartForCompleteDeferred() async {
   try {
     final cart = FFAppState().cart;
@@ -48,7 +104,7 @@ Map<String, dynamic> _buildCartPayloadFromShoppingCart(ShoppingCartStruct cart) 
       'quantity': cartItem.cartItemQuantity,
       'unit_price': unitPrice,
       'discount_amount': discountAmount,
-      'tax_rate': 0.25,
+      'tax_rate': resolveCartItemTaxRate(cartItem),
       'tax_inclusive': true,
     });
   }

--- a/docs/flutterflow/custom-actions/update_cart_totals.dart
+++ b/docs/flutterflow/custom-actions/update_cart_totals.dart
@@ -1,138 +1,173 @@
+import 'package:mek_stripe_terminal/mek_stripe_terminal.dart';
+
 // Prevent concurrent updates
 bool _isUpdatingTotals = false;
 
-/// Get tax percentage from tax code
-/// Maps tax codes to tax percentages
-/// Returns default 25% if code is not recognized
+/// Maps tax codes / article group hints to decimal VAT rate (0–1).
 double getTaxPercentageFromCode(String? taxCode) {
   if (taxCode == null || taxCode.isEmpty) {
-    return 0.25; // Default 25% VAT in Norway
+    return 0.25;
   }
-  
-  // Stripe tax codes and common tax code formats
+
   switch (taxCode.toLowerCase()) {
     case 'txcd_99999999':
     case 'standard':
-    case '1': // SAF-T standard rate code
-      return 0.25; // 25% standard VAT
+    case '1':
+      return 0.25;
     case 'txcd_99999998':
     case 'reduced':
     case 'food':
-      return 0.15; // 15% reduced rate (food)
+      return 0.15;
     case 'txcd_99999997':
     case 'lower':
     case 'service':
-      return 0.10; // 10% lower rate
+      return 0.10;
     case 'txcd_99999996':
     case 'zero':
     case 'exempt':
     case '0':
-      return 0.0; // 0% exempt
+      return 0.0;
     default:
-      // Default to 25% if code is not recognized
       return 0.25;
   }
 }
 
-/// Calculate and update all cart totals with per-product tax calculation
-/// This action calculates totals and stores them in the cart struct fields:
-/// - cartTotalLinePrice
-/// - cartTotalItemDiscounts
-/// - cartTotalCartDiscounts
-/// - cartTotalDiscount
-/// - cartSubtotalExcludingTax
-/// - cartTotalTax (calculated per item based on tax code)
-/// - cartTotalCartPrice
-/// 
-/// Includes protection against concurrent updates to prevent rendering errors
+/// Normalize API/product tax percent to decimal rate 0–1.
+double normalizeTaxRateDecimal(double? rate, {double defaultRate = 0.25}) {
+  if (rate == null) {
+    return defaultRate;
+  }
+  if (rate == 0) {
+    return 0.0;
+  }
+  if (rate > 1) {
+    return rate / 100.0;
+  }
+
+  return rate;
+}
+
+/// Resolve effective VAT decimal rate for a cart line (0–1).
+double resolveCartItemTaxRate(CartItemsStruct item) {
+  final stored = item.cartItemTaxPercent;
+  if (stored != null) {
+    return normalizeTaxRateDecimal(stored);
+  }
+
+  final code = item.cartItemArticleGroupCode.trim();
+  if (code.isNotEmpty) {
+    return getTaxPercentageFromCode(code);
+  }
+
+  return 0.25;
+}
+
+/// Calculate and update all cart totals with per-product tax calculation.
 Future updateCartTotals() async {
-  // Prevent concurrent updates to avoid rendering errors
   if (_isUpdatingTotals) {
     return;
   }
-  
+
   _isUpdatingTotals = true;
-  
+
   try {
     final cart = FFAppState().cart;
-  
-  // Initialize totals
-  int totalLinePrice = 0;
-  int totalItemDiscounts = 0;
-  int totalCartDiscounts = 0;
-  int totalTax = 0; // Will be calculated per item
-  
-  // Calculate line items totals and tax per item
-  // Note: Prices are tax-inclusive, so we need to extract tax from the price
-  for (var item in cart.cartItems) {
-    // Line price = unit price * quantity (this is tax-inclusive)
-    // Round to int since prices are in øre (smallest currency unit)
-    final linePrice = (item.cartItemUnitPrice * item.cartItemQuantity).round();
-    totalLinePrice += linePrice;
-    
-    // Item discount = discount amount * quantity
-    // Round to int since amounts are in øre
-    final itemDiscount = ((item.cartItemDiscountAmount ?? 0) * item.cartItemQuantity).round();
-    totalItemDiscounts += itemDiscount;
-    
-    // Calculate item subtotal (after discount, still tax-inclusive)
-    final itemSubtotalIncludingTax = linePrice - itemDiscount;
-    
-    // Get tax percentage from article group code (stored when adding to cart)
-    // The cartItemArticleGroupCode contains the tax code from the product
-    final taxPercentage = getTaxPercentageFromCode(item.cartItemArticleGroupCode);
-    
-    // Calculate tax for this item (extract tax from tax-inclusive price)
-    // Formula: Tax = Price including tax × (Tax rate / (1 + Tax rate))
-    // Example: If price is 100 and tax is 25%, tax = 100 × (0.25 / 1.25) = 20
-    final itemTax = taxPercentage > 0
-        ? (itemSubtotalIncludingTax * (taxPercentage / (1 + taxPercentage))).round()
-        : 0;
-    totalTax += itemTax;
-  }
-  
-  // Calculate cart-level discounts
-  for (var discount in cart.cartDiscounts) {
-    totalCartDiscounts += discount.cartDiscountAmount;
-  }
-  
-  // Calculate final totals
-  final totalDiscount = totalItemDiscounts + totalCartDiscounts;
-  
-  // Subtotal excluding tax = total line price (tax-inclusive) - discounts - tax
-  // Since prices include tax, we subtract the tax to get the base price
-  final subtotalExcludingTax = totalLinePrice - totalDiscount - totalTax;
-  
-  // Total cart price = subtotal excluding tax + tax + tip
-  // Or simply: total line price - discounts + tip (since line price already includes tax)
-  final totalCartPrice = totalLinePrice - totalDiscount + (cart.cartTipAmount ?? 0);
-  
-  // Update cart with calculated totals
-  FFAppState().update(() {
-    FFAppState().cart = ShoppingCartStruct(
-      cartId: cart.cartId,
-      cartPosSessionId: cart.cartPosSessionId,
-      cartItems: cart.cartItems,
-      cartDiscounts: cart.cartDiscounts,
-      cartTipAmount: cart.cartTipAmount,
-      cartCustomerId: cart.cartCustomerId,
-      cartCustomerName: cart.cartCustomerName,
-      cartCreatedAt: cart.cartCreatedAt,
-      cartUpdatedAt: getCurrentTimestamp.toString(),
-      cartMetadata: cart.cartMetadata,
-      cartNote: cart.cartNote,
-      // Store calculated totals
-      cartTotalLinePrice: totalLinePrice,
-      cartTotalItemDiscounts: totalItemDiscounts,
-      cartTotalCartDiscounts: totalCartDiscounts,
-      cartTotalDiscount: totalDiscount,
-      cartSubtotalExcludingTax: subtotalExcludingTax,
-      cartTotalTax: totalTax,
-      cartTotalCartPrice: totalCartPrice,
-    );
-  });
+
+    int totalLinePrice = 0;
+    int totalItemDiscounts = 0;
+    int totalCartDiscounts = 0;
+    int totalTax = 0;
+
+    for (var item in cart.cartItems) {
+      final linePrice = (item.cartItemUnitPrice * item.cartItemQuantity).round();
+      totalLinePrice += linePrice;
+
+      final itemDiscount =
+          ((item.cartItemDiscountAmount ?? 0) * item.cartItemQuantity).round();
+      totalItemDiscounts += itemDiscount;
+
+      final itemSubtotalIncludingTax = linePrice - itemDiscount;
+      final taxPercentage = resolveCartItemTaxRate(item);
+
+      final itemTax = taxPercentage > 0
+          ? (itemSubtotalIncludingTax * (taxPercentage / (1 + taxPercentage)))
+              .round()
+          : 0;
+      totalTax += itemTax;
+    }
+
+    for (var discount in cart.cartDiscounts) {
+      totalCartDiscounts += discount.cartDiscountAmount;
+    }
+
+    final totalDiscount = totalItemDiscounts + totalCartDiscounts;
+    final subtotalExcludingTax = totalLinePrice - totalDiscount - totalTax;
+    final totalCartPrice =
+        totalLinePrice - totalDiscount + (cart.cartTipAmount ?? 0);
+
+    FFAppState().update(() {
+      FFAppState().cart = ShoppingCartStruct(
+        cartId: cart.cartId,
+        cartPosSessionId: cart.cartPosSessionId,
+        cartItems: cart.cartItems,
+        cartDiscounts: cart.cartDiscounts,
+        cartTipAmount: cart.cartTipAmount,
+        cartCustomerId: cart.cartCustomerId,
+        cartCustomerName: cart.cartCustomerName,
+        cartCreatedAt: cart.cartCreatedAt,
+        cartUpdatedAt: getCurrentTimestamp.toString(),
+        cartMetadata: cart.cartMetadata,
+        cartNote: cart.cartNote,
+        cartTotalLinePrice: totalLinePrice,
+        cartTotalItemDiscounts: totalItemDiscounts,
+        cartTotalCartDiscounts: totalCartDiscounts,
+        cartTotalDiscount: totalDiscount,
+        cartSubtotalExcludingTax: subtotalExcludingTax,
+        cartTotalTax: totalTax,
+        cartTotalCartPrice: totalCartPrice,
+      );
+    });
+
+    if (!FFAppState().stripeReaderConnected) {
+      return;
+    }
+
+    final updatedCart = FFAppState().cart;
+    try {
+      if (updatedCart.cartItems.isEmpty) {
+        await Terminal.instance.clearReaderDisplay();
+      } else {
+        final lineItems = updatedCart.cartItems.map((item) {
+          final unitPrice = item.cartItemUnitPrice ?? 0;
+          final qty = item.cartItemQuantity.round();
+          final discount =
+              ((item.cartItemDiscountAmount ?? 0) * item.cartItemQuantity)
+                  .round();
+          final amount = (unitPrice * item.cartItemQuantity).round() - discount;
+          String description = item.cartItemProductName.isNotEmpty
+              ? item.cartItemProductName
+              : (item.cartItemDescription.isNotEmpty
+                  ? item.cartItemDescription
+                  : 'Item');
+          if (description.length > 50) {
+            description = '${description.substring(0, 47)}...';
+          }
+          return CartLineItem(
+            description: description,
+            quantity: qty,
+            amount: amount,
+          );
+        }).toList();
+        final stripeCart = Cart(
+          currency: 'nok',
+          tax: updatedCart.cartTotalTax,
+          total: updatedCart.cartTotalCartPrice,
+          lineItems: lineItems,
+        );
+        await Terminal.instance.setReaderDisplay(stripeCart);
+      }
+    } catch (_) {}
   } finally {
     _isUpdatingTotals = false;
   }
 }
-

--- a/docs/flutterflow/dsl/upsert_checkout_vat_rates.dart
+++ b/docs/flutterflow/dsl/upsert_checkout_vat_rates.dart
@@ -1,0 +1,194 @@
+library;
+
+import 'dart:io';
+
+import 'package:flutterflow_ai/flutterflow_ai.dart';
+
+import 'flutterflow_custom_action_api_body.dart';
+
+/// Push checkout VAT fixes into FlutterFlow POSitiv (`pointofsale-xrlz5i`).
+Future<void> main(List<String> args) async {
+  final options = _parseCliOptions(args);
+  final scriptDir = File(Platform.script.toFilePath()).parent;
+  final repoRoot = scriptDir.parent.parent;
+  final actionsDir = Directory('${repoRoot.path}/docs/flutterflow/custom-actions');
+
+  final specs = <_ActionSpec>[
+    _ActionSpec(
+      name: 'updateCartTotals',
+      file: File('${actionsDir.path}/update_cart_totals.dart'),
+      description:
+          'Recalculate cart totals with per-line VAT; preserve cartNote.',
+    ),
+    _ActionSpec(
+      name: 'completePosPurchase',
+      file: File('${actionsDir.path}/complete_pos_purchase.dart'),
+      description:
+          'Complete POS purchase with per-item tax_rate from cart line VAT.',
+    ),
+    _ActionSpec(
+      name: 'serializeCartForCompleteDeferred',
+      file: File('${actionsDir.path}/serialize_cart_for_complete_deferred.dart'),
+      description:
+          'Serialize cart for deferred completion with correct tax_rate per line.',
+    ),
+    _ActionSpec(
+      name: 'prepareParkedDeferredPurchase',
+      file: File('${actionsDir.path}/prepare_parked_deferred_purchase.dart'),
+      description:
+          'Hydrate parked deferred cart and serialize with correct per-line VAT.',
+    ),
+  ];
+
+  for (final s in specs) {
+    if (!s.file.existsSync()) {
+      stderr.writeln('Missing source file: ${s.file.path}');
+      exit(1);
+    }
+  }
+
+  try {
+    await flutterFlowAI(
+      (app) {
+        app.raw((project) {
+          for (final s in specs) {
+            final code = customActionCodeForFlutterFlowApi(s.file.readAsStringSync());
+            final existing = findCustomAction(project, name: s.name);
+            if (existing == null) {
+              throw StateError('Custom action ${s.name} not found in project.');
+            }
+            updateCustomAction(
+              project,
+              name: s.name,
+              code: code,
+              description: s.description,
+            );
+          }
+        });
+      },
+      apiKey: options.apiKey,
+      baseUrl: options.baseUrl,
+      projectName: options.projectName,
+      projectId: options.projectId,
+      findOrCreate: options.findOrCreate,
+      allowNewProject: options.allowNewProject,
+      dryRun: options.dryRun,
+      commitMessage:
+          options.commitMessage ??
+          'fix(pos): per-item VAT tax_rate on checkout flows',
+    );
+  } catch (error) {
+    stderr.writeln('Error: ${formatFlutterFlowAIError(error)}');
+    exit(1);
+  }
+}
+
+final class _ActionSpec {
+  const _ActionSpec({
+    required this.name,
+    required this.file,
+    required this.description,
+  });
+
+  final String name;
+  final File file;
+  final String description;
+}
+
+final class _CliOptions {
+  const _CliOptions({
+    this.apiKey,
+    this.baseUrl,
+    this.projectName,
+    this.projectId,
+    this.findOrCreate = false,
+    this.allowNewProject = false,
+    this.dryRun = false,
+    this.commitMessage,
+  });
+
+  final String? apiKey;
+  final String? baseUrl;
+  final String? projectName;
+  final String? projectId;
+  final bool findOrCreate;
+  final bool allowNewProject;
+  final bool dryRun;
+  final String? commitMessage;
+}
+
+_CliOptions _parseCliOptions(List<String> args) {
+  String? apiKey;
+  String? baseUrl;
+  String? projectName;
+  String? projectId;
+  String? commitMessage;
+  var findOrCreate = false;
+  var allowNewProject = false;
+  var dryRun = false;
+
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        _printUsage();
+        exit(0);
+      case '--api-key':
+        apiKey = _requireValue(args, ++i, '--api-key');
+      case '--base-url':
+        baseUrl = _requireValue(args, ++i, '--base-url');
+      case '--project-name':
+        projectName = _requireValue(args, ++i, '--project-name');
+      case '--project-id':
+        projectId = _requireValue(args, ++i, '--project-id');
+      case '--commit-message':
+        commitMessage = _requireValue(args, ++i, '--commit-message');
+      case '--find-or-create':
+        findOrCreate = true;
+      case '--allow-new-project':
+        allowNewProject = true;
+      case '--dry-run':
+        dryRun = true;
+      default:
+        stderr.writeln('Unknown option: $arg');
+        _printUsage();
+        exit(64);
+    }
+  }
+
+  return _CliOptions(
+    apiKey:
+        apiKey ??
+        Platform.environment['FLUTTERFLOW_AI_API_KEY'] ??
+        Platform.environment['FF_API_KEY'],
+    baseUrl: baseUrl,
+    projectName: projectName,
+    projectId:
+        projectId ??
+        Platform.environment['FLUTTERFLOW_POSITIV_PROJECT_ID'] ??
+        'pointofsale-xrlz5i',
+    findOrCreate: findOrCreate,
+    allowNewProject: allowNewProject,
+    dryRun: dryRun,
+    commitMessage: commitMessage,
+  );
+}
+
+String _requireValue(List<String> args, int index, String flag) {
+  if (index >= args.length) {
+    stderr.writeln('Missing value for $flag.');
+    _printUsage();
+    exit(64);
+  }
+  return args[index];
+}
+
+void _printUsage() {
+  stdout.writeln('''
+Push checkout VAT fixes to FlutterFlow POSitiv.
+
+Usage:
+  dart run dsl/upsert_checkout_vat_rates.dart [options]
+''');
+}

--- a/tests/Feature/PurchaseVatBreakdownTest.php
+++ b/tests/Feature/PurchaseVatBreakdownTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Filament\Resources\PosPurchases\Schemas\PosPurchaseInfolist;
+use App\Models\ArticleGroupCode;
+use App\Models\ConnectedCharge;
+use App\Models\ConnectedProduct;
+use App\Models\PaymentMethod;
+use App\Models\PosDevice;
+use App\Models\PosSession;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\ReceiptTemplateService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('resolves 15 percent vat on purchase items when client sends wrong tax rate', function () {
+    $user = User::factory()->create();
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_vat_15']);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    ArticleGroupCode::query()->create([
+        'code' => 'EGG',
+        'name' => 'Egg',
+        'default_vat_percent' => 0.15,
+        'active' => true,
+    ]);
+
+    $product = ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'article_group_code' => 'EGG',
+        'vat_percent' => 15.00,
+    ]);
+
+    $posDevice = PosDevice::factory()->create(['store_id' => $store->id, 'cash_drawer_enabled' => true]);
+    $session = PosSession::factory()->create([
+        'store_id' => $store->id,
+        'pos_device_id' => $posDevice->id,
+        'user_id' => $user->id,
+        'status' => 'open',
+    ]);
+
+    PaymentMethod::create([
+        'store_id' => $store->id,
+        'name' => 'Cash',
+        'code' => 'cash',
+        'provider' => 'cash',
+        'enabled' => true,
+        'pos_suitable' => true,
+        'sort_order' => 0,
+        'minimum_amount_kroner' => null,
+        'saf_t_payment_code' => '10000',
+        'saf_t_event_code' => '13016',
+    ]);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->postJson('/api/purchases', [
+        'pos_session_id' => $session->id,
+        'payment_method_code' => 'cash',
+        'cart' => [
+            'items' => [
+                [
+                    'product_id' => $product->id,
+                    'quantity' => 1,
+                    'unit_price' => 4500,
+                    'tax_rate' => 0.25,
+                    'tax_inclusive' => true,
+                ],
+            ],
+            'subtotal' => 3913,
+            'total_tax' => 587,
+            'total_discounts' => 0,
+            'total' => 4500,
+            'currency' => 'nok',
+        ],
+    ]);
+
+    $response->assertStatus(201);
+
+    $charge = ConnectedCharge::query()->latest('id')->first();
+    expect($charge)->not->toBeNull();
+
+    $items = $charge->metadata['items'] ?? [];
+    expect($items)->toHaveCount(1)
+        ->and((float) $items[0]['tax_rate'])->toBe(0.15);
+
+    $breakdown = PosPurchaseInfolist::buildTaxBreakdownForRecord($charge);
+    expect($breakdown)->toHaveCount(1)
+        ->and($breakdown[0]['rate'])->toBe('15%')
+        ->and($breakdown[0]['amount'])->toBe('5.87 NOK');
+});
+
+it('builds receipt vat breakdown at 15 percent for food items', function () {
+    $store = Store::factory()->create();
+    $charge = ConnectedCharge::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'amount' => 4500,
+        'metadata' => [
+            'subtotal' => 3913,
+            'total_tax' => 587,
+            'items' => [
+                [
+                    'unit_price' => 4500,
+                    'quantity' => 1,
+                    'discount_amount' => 0,
+                    'tax_rate' => 0.15,
+                    'product_name' => 'Egg product',
+                ],
+            ],
+        ],
+    ]);
+
+    $service = app(ReceiptTemplateService::class);
+    $reflection = new ReflectionMethod($service, 'buildVatBreakdownFromItems');
+    $reflection->setAccessible(true);
+
+    $result = $reflection->invoke($service, $charge->metadata['items'], 45.0, $charge->metadata);
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]['vat_rate'])->toBe(15.0)
+        ->and($result[0]['vat_base'])->toBe(39.13)
+        ->and($result[0]['vat_amount'])->toBe(5.87);
+});
+
+it('exposes purchase item tax rate in purchase api response', function () {
+    $user = User::factory()->create();
+    $store = Store::factory()->create(['stripe_account_id' => 'acct_vat_api']);
+    $user->stores()->attach($store);
+    $user->setCurrentStore($store);
+
+    $product = ConnectedProduct::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'vat_percent' => 15.00,
+    ]);
+
+    $charge = ConnectedCharge::factory()->create([
+        'stripe_account_id' => $store->stripe_account_id,
+        'amount' => 4500,
+        'metadata' => [
+            'items' => [
+                [
+                    'id' => 'line-1',
+                    'product_id' => $product->id,
+                    'unit_price' => 4500,
+                    'quantity' => 1,
+                    'discount_amount' => 0,
+                    'tax_rate' => 0.15,
+                ],
+            ],
+            'subtotal' => 3913,
+            'total_tax' => 587,
+        ],
+    ]);
+
+    Sanctum::actingAs($user, ['*']);
+
+    $response = $this->getJson("/api/purchases/{$charge->id}");
+
+    $response->assertOk();
+    expect($response->json('purchase.purchase_items.0.purchase_item_tax_rate'))->toBe(0.15);
+});


### PR DESCRIPTION
## Summary
- Fix checkout flows to send each cart line's actual VAT rate (`resolveCartItemTaxRate`) instead of hardcoded 25% in `completePosPurchase`, `serializeCartForCompleteDeferred`, and `prepareParkedDeferredPurchase`.
- Recalculate cart totals before checkout and use `cartItemTaxPercent` with tax-code/article-group fallbacks in `updateCartTotals`.
- Harden backend: resolve and store `tax_rate` from product VAT on purchase save, normalize rates in Filament purchase view and receipt MVA breakdown, expose `purchase_item_tax_rate` on the purchases API for deferred cart hydration.
- Pushed matching FlutterFlow custom actions to POSitiv (`pointofsale-xrlz5i`, commit `BUG7TOYsK3gm2XfCohxg`).

## Test plan
- [x] `php artisan test --compact tests/Feature/PurchaseVatBreakdownTest.php`
- [ ] Sync/download latest custom code in FlutterFlow Desktop
- [ ] Sell a 15% VAT food item — Filament purchase subtotal/tax and receipt MVA should both show 15% (e.g. 45 NOK → base 39.13, MVA 5.87)
- [ ] Complete a parked deferred order after editing cart — VAT should remain correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VAT/tax-rate normalization and storage across checkout payloads, purchase persistence, receipt rendering, and API responses, which can affect financial reporting if incorrect. Changes are scoped and backed by new feature tests, but impact a critical calculation path.
> 
> **Overview**
> **Per-item VAT is now treated as a first-class, normalized value end-to-end.** A new `VatRateNormalizer` standardizes VAT rates to decimal form and is applied when reading article group defaults, purchase metadata `tax_rate`, and when generating VAT breakdowns.
> 
> On the backend, purchase item enrichment now resolves/stores `tax_rate` from the underlying product VAT (falling back to normalized client input or 25% default) and the purchases API response includes `purchase_item_tax_rate` for clients.
> 
> On the FlutterFlow side, checkout/deferred flows stop hardcoding 25% and instead compute `tax_rate` per cart line (including a new shared helper pattern), recalculate totals before checkout, and preserve VAT when hydrating parked deferred purchases. Added feature tests cover correcting a wrong client tax rate, receipt VAT breakdown, and API exposure of item tax rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4226b98d54fb8ac6f2b36e6891bdbca054ab8f29. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->